### PR TITLE
Attempted Elevator Fix

### DIFF
--- a/maps/fairpoint/fairpoint-1.dmm
+++ b/maps/fairpoint/fairpoint-1.dmm
@@ -611,6 +611,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/exam_room)
+"uP" = (
+/obj/abstract/level_data/main_level,
+/turf/simulated/wall/r_wall/hull,
+/area/fairpoint/maintenance/arrivals)
 "uY" = (
 /obj/effect/floor_decal/corner/white/border{
 	dir = 4
@@ -1112,7 +1116,6 @@
 /turf/simulated/wall/iron,
 /area/turbolift/sewer_exit)
 "Pn" = (
-/obj/structure/lift/button,
 /turf/simulated/wall/concrete,
 /area/turbolift/metro_maintenance)
 "PD" = (
@@ -1597,7 +1600,7 @@ AM
 AM
 AM
 AM
-AM
+uP
 "}
 (2,1,1) = {"
 iR

--- a/maps/fairpoint/fairpoint-1.dmm
+++ b/maps/fairpoint/fairpoint-1.dmm
@@ -4,12 +4,11 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/morgue)
 "aw" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_sewers)
+/turf/simulated/wall/iron,
+/area/fairpoint/maintenance/arrivals)
 "az" = (
 /obj/structure/morgue{
 	dir = 4
@@ -56,6 +55,12 @@
 "bD" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/morgue)
+"ca" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/turf/simulated/wall/iron,
+/area/fairpoint/maintenance/arrivals)
 "cb" = (
 /obj/effect/floor_decal/corner/blue/border,
 /obj/effect/floor_decal/corner/blue/border{
@@ -126,12 +131,11 @@
 	},
 /area/fairpoint/medical/exam_room)
 "dK" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_sewers)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/fairpoint/maintenance/arrivals)
 "dN" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 8
@@ -267,13 +271,28 @@
 /area/fairpoint/medical/medbay)
 "jh" = (
 /obj/turbolift_map_holder/fairpoint/metro{
-	level = 3;
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/turbolift/metro_maintenance)
 "jm" = (
 /turf/exterior/barren,
+/area/fairpoint/maintenance/arrivals)
+"jv" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
+"jG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "jI" = (
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -360,6 +379,13 @@
 "lv" = (
 /obj/machinery/door/blast/regular,
 /turf/simulated/floor/plating,
+/area/fairpoint/maintenance/arrivals)
+"lF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/exterior/water/chlorine,
 /area/fairpoint/maintenance/arrivals)
 "lW" = (
 /obj/structure/closet/secure_closet/freezer{
@@ -457,8 +483,13 @@
 /area/turbolift/sewer_exit)
 "ps" = (
 /obj/turbolift_map_holder/fairpoint/cargo,
-/turf/exterior/concrete/pavement/empty,
+/turf/simulated/floor/tiled/techmaint,
 /area/turbolift/sewer_exit/mining)
+"pC" = (
+/obj/effect/floor_decal/corner/paleblue,
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "pE" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/maintenance/arrivals)
@@ -542,10 +573,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
+"sg" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/fairpoint/maintenance/arrivals)
 "si" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
+/turf/simulated/floor/tiled/techmaint,
+/area/fairpoint/maintenance/arrivals)
+"sl" = (
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "sC" = (
@@ -590,10 +631,15 @@
 /turf/exterior/water,
 /area/fairpoint/maintenance/arrivals)
 "tE" = (
-/obj/effect/floor_decal/corner/paleblue,
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_sewers)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/exterior/water/chlorine,
+/area/fairpoint/maintenance/arrivals)
+"tG" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/wall/iron,
+/area/fairpoint/maintenance/arrivals)
 "tL" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
@@ -683,6 +729,13 @@
 /obj/item/chems/ivbag/blood/OMinus,
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
+"wM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/fairpoint/maintenance/arrivals)
 "xa" = (
 /obj/structure/morgue,
 /obj/structure/window/reinforced{
@@ -715,6 +768,10 @@
 /area/fairpoint/medical/ward)
 "yR" = (
 /obj/machinery/door/airlock/hatch/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/wall/iron,
 /area/fairpoint/maintenance/arrivals)
 "yS" = (
@@ -733,6 +790,10 @@
 /turf/simulated/floor/pool,
 /turf/simulated/wall/iron,
 /area/fairpoint/maintenance/arrivals)
+"Ae" = (
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "Ag" = (
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/morgue)
@@ -769,7 +830,7 @@
 /area/fairpoint/maintenance/arrivals)
 "AN" = (
 /obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/tiled,
+/turf/space,
 /area/fairpoint/hallway/secondary/exit)
 "AS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -798,6 +859,13 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/exam_room)
+"BW" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "BY" = (
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
@@ -862,9 +930,12 @@
 /turf/simulated/floor/plating,
 /area/turbolift/hospital_sewers)
 "Es" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/tiled,
-/area/fairpoint/hallway/secondary/exit)
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/exterior/water/chlorine,
+/area/fairpoint/maintenance/arrivals)
 "Ev" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/white,
@@ -898,6 +969,16 @@
 /area/fairpoint/hallway/secondary/exit)
 "Fw" = (
 /turf/simulated/floor,
+/area/fairpoint/maintenance/arrivals)
+"Fy" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	tag = "icon-bordercolor (WEST)";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/steel_ridged,
 /area/fairpoint/maintenance/arrivals)
 "Ga" = (
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -942,7 +1023,6 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/maintenance/arrivals)
 "Ha" = (
-/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/turbolift/hospital_sewers)
 "He" = (
@@ -1031,6 +1111,16 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/hallway/secondary/exit)
+"Jv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/grey/border{
+	tag = "icon-bordercolor (WEST)";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/fairpoint/maintenance/arrivals)
 "JE" = (
 /obj/structure/morgue{
 	dir = 8
@@ -1124,6 +1214,16 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/morgue)
+"Nu" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/wall/iron,
+/area/fairpoint/maintenance/arrivals)
+"NL" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/fairpoint/maintenance/arrivals)
 "NN" = (
 /turf/simulated/wall/elevator,
 /area/fairpoint/maintenance/arrivals)
@@ -1132,11 +1232,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
 "Oc" = (
-/obj/structure/sign/warning/moving_parts,
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/fairpoint/medical/exam_room)
+/obj/structure/disposalpipe/segment,
+/turf/exterior/water/chlorine,
+/area/fairpoint/maintenance/arrivals)
 "Ol" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -1155,6 +1253,12 @@
 "OX" = (
 /turf/simulated/wall/iron,
 /area/turbolift/sewer_exit)
+"Pb" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/turf/exterior/water/chlorine,
+/area/fairpoint/maintenance/arrivals)
 "Pn" = (
 /obj/structure/lift/button,
 /turf/simulated/wall/concrete,
@@ -1168,7 +1272,7 @@
 /turf/exterior/water,
 /area/fairpoint/maintenance/arrivals)
 "PI" = (
-/turf/exterior/concrete/pavement/empty,
+/turf/simulated/floor/tiled/techmaint,
 /area/turbolift/sewer_exit/mining)
 "PK" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1193,9 +1297,11 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/fairpoint/maintenance/arrivals)
 "QF" = (
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/plating,
-/area/turbolift/sewer_exit)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/fairpoint/maintenance/arrivals)
 "QN" = (
 /obj/structure/closet/secure_closet/freezer{
 	name = "blood storage"
@@ -1213,6 +1319,12 @@
 "Rd" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/maintenance/hospital)
+"Rg" = (
+/obj/structure/sign/warning/moving_parts,
+/turf/simulated/wall/prepainted{
+	color = "FFFEFD"
+	},
+/area/fairpoint/medical/medbay)
 "Rk" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1249,6 +1361,13 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/hallway/secondary/exit)
+"RJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/exterior/water/chlorine,
+/area/fairpoint/maintenance/arrivals)
 "RQ" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer,
@@ -1288,6 +1407,13 @@
 /obj/effect/catwalk_plated,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
+/area/fairpoint/maintenance/arrivals)
+"Tb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/iron,
 /area/fairpoint/maintenance/arrivals)
 "Ti" = (
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -1334,6 +1460,21 @@
 "UM" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/hallway/secondary/exit)
+"UP" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1;
+	tag = "icon-warning_dust (NORTH)"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/fairpoint/maintenance/arrivals)
+"Vd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/iron,
+/area/fairpoint/maintenance/arrivals)
 "Vk" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
@@ -1382,6 +1523,13 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
+"Xh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/wall/iron,
+/area/fairpoint/maintenance/arrivals)
 "Xn" = (
 /turf/simulated/wall/prepainted{
 	color = "FFFEFD"
@@ -1415,6 +1563,13 @@
 	color = "FFFEFD"
 	},
 /area/fairpoint/medical/morgue)
+"XN" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/fairpoint/maintenance/arrivals)
 "XR" = (
 /obj/structure/table/reinforced,
 /obj/item/scanner/autopsy,
@@ -7629,7 +7784,7 @@ kt
 kt
 kt
 jT
-Es
+mU
 UM
 UM
 UM
@@ -9305,10 +9460,10 @@ kt
 kt
 kt
 kt
-kt
-kt
-kt
-kt
+tG
+tG
+tG
+tG
 kt
 kt
 kt
@@ -9468,7 +9623,7 @@ kt
 kt
 kt
 kt
-kt
+aw
 kt
 It
 It
@@ -9627,7 +9782,7 @@ kt
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 It
@@ -9786,7 +9941,7 @@ kt
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -9945,7 +10100,7 @@ kt
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -10104,7 +10259,7 @@ kt
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -10263,7 +10418,7 @@ kt
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -10422,7 +10577,7 @@ kt
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -10572,16 +10727,16 @@ kr
 kr
 kt
 kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
+Vd
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+Xh
 kt
 kt
 kt
@@ -10731,7 +10886,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kr
@@ -10890,7 +11045,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kr
@@ -11049,7 +11204,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -11208,7 +11363,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -11367,7 +11522,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -11526,7 +11681,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -11685,7 +11840,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -11693,55 +11848,55 @@ KF
 KF
 KF
 KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-kt
-QB
-QB
-kt
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-QB
-QB
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-QB
-QB
-KF
-KF
-KF
-KF
-KF
-KF
+lF
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+tG
+NL
+NL
+tG
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+NL
+NL
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+NL
+NL
+Oc
+Oc
+Oc
+Oc
+Oc
+RJ
 KF
 KF
 KF
@@ -11844,7 +11999,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -11852,7 +12007,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 KF
 KF
 KF
@@ -11900,7 +12055,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 KF
 KF
 KF
@@ -12003,7 +12158,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -12011,7 +12166,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 Ud
 Ud
@@ -12059,7 +12214,7 @@ kt
 kt
 KF
 KF
-KF
+tE
 KF
 KF
 kt
@@ -12162,7 +12317,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -12170,7 +12325,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 kr
 kr
@@ -12218,36 +12373,36 @@ kt
 kt
 KF
 KF
-KF
-KF
-KF
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kr
-kr
+Es
+Oc
+Oc
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+sl
+jG
 kr
 kr
 kr
@@ -12321,7 +12476,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -12329,7 +12484,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -12406,7 +12561,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kr
 kr
@@ -12480,7 +12635,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -12488,7 +12643,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -12565,7 +12720,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 kt
@@ -12639,7 +12794,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -12647,7 +12802,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -12724,7 +12879,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -12798,7 +12953,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -12806,7 +12961,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -12883,7 +13038,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -12957,7 +13112,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -12965,7 +13120,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -13042,7 +13197,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -13116,7 +13271,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -13124,7 +13279,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -13201,7 +13356,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -13275,7 +13430,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -13283,7 +13438,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -13360,7 +13515,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -13434,7 +13589,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -13442,7 +13597,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -13519,7 +13674,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -13593,7 +13748,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -13601,7 +13756,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -13678,7 +13833,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -13752,7 +13907,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -13760,7 +13915,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -13837,7 +13992,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -13911,7 +14066,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -13919,7 +14074,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -13996,7 +14151,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -14070,7 +14225,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -14078,7 +14233,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -14155,7 +14310,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -14229,7 +14384,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -14237,7 +14392,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -14314,7 +14469,7 @@ KF
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -14388,7 +14543,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -14396,7 +14551,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -14473,7 +14628,7 @@ KF
 KF
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -14547,7 +14702,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -14555,7 +14710,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -14632,7 +14787,7 @@ KF
 KF
 KF
 QB
-kr
+QF
 kr
 kt
 ea
@@ -14706,7 +14861,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -14714,7 +14869,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -14791,7 +14946,7 @@ QB
 QB
 QB
 QB
-kr
+QF
 kr
 kt
 ea
@@ -14865,7 +15020,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -14873,7 +15028,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -14950,7 +15105,7 @@ QB
 QB
 QB
 QB
-kr
+QF
 kr
 kt
 ea
@@ -15024,7 +15179,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -15032,7 +15187,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -15109,7 +15264,7 @@ QB
 QB
 QB
 QB
-kr
+QF
 kr
 kt
 ea
@@ -15183,7 +15338,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -15191,7 +15346,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -15268,7 +15423,7 @@ KF
 KF
 KF
 QB
-kr
+QF
 kr
 kt
 ea
@@ -15342,7 +15497,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -15350,7 +15505,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -15427,7 +15582,7 @@ KF
 KF
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -15501,7 +15656,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -15509,7 +15664,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -15586,7 +15741,7 @@ KF
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -15660,7 +15815,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -15668,7 +15823,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -15745,7 +15900,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -15819,7 +15974,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -15827,7 +15982,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -15904,7 +16059,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -15978,7 +16133,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -15986,7 +16141,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -16063,7 +16218,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -16137,7 +16292,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -16145,7 +16300,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -16222,7 +16377,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -16296,7 +16451,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -16304,7 +16459,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -16381,7 +16536,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -16455,7 +16610,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -16463,7 +16618,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -16540,7 +16695,7 @@ kt
 kt
 kt
 kr
-kr
+XN
 kr
 kt
 ea
@@ -16614,7 +16769,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -16622,7 +16777,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -16699,7 +16854,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -16773,7 +16928,7 @@ kr
 kr
 kt
 kt
-kt
+aw
 kr
 kr
 kt
@@ -16781,7 +16936,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -16858,7 +17013,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 ea
@@ -16932,7 +17087,7 @@ kr
 Si
 kt
 kt
-kt
+aw
 GD
 kr
 kt
@@ -16940,7 +17095,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -17017,7 +17172,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -17091,7 +17246,7 @@ kr
 Si
 kt
 kt
-kt
+aw
 GD
 kr
 kt
@@ -17099,7 +17254,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -17176,7 +17331,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -17187,8 +17342,8 @@ Yo
 PD
 gb
 iV
-zq
 ne
+YQ
 YQ
 YQ
 vW
@@ -17251,13 +17406,13 @@ Si
 ZG
 kr
 yR
-GD
-kr
-kt
-KF
-KF
-KF
-KF
+UP
+sl
+tG
+Oc
+Oc
+Oc
+Oc
 nD
 Ud
 QB
@@ -17335,7 +17490,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -17346,9 +17501,9 @@ UE
 UE
 gb
 ZJ
-zq
-aw
+jM
 Hg
+go
 go
 go
 go
@@ -17417,7 +17572,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -17494,7 +17649,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -17505,8 +17660,8 @@ UE
 UE
 gs
 zq
-zq
-dK
+BW
+go
 El
 El
 El
@@ -17576,7 +17731,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -17653,7 +17808,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -17664,7 +17819,7 @@ Yo
 PD
 PS
 nk
-zq
+Ae
 Ha
 El
 El
@@ -17735,7 +17890,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -17812,7 +17967,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -17823,7 +17978,7 @@ Ev
 bl
 bl
 ma
-zq
+Ae
 Ha
 El
 El
@@ -17894,7 +18049,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -17971,7 +18126,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -17982,7 +18137,7 @@ Yo
 PD
 qX
 tq
-zq
+Ae
 Ha
 El
 El
@@ -18053,7 +18208,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -18130,7 +18285,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -18141,8 +18296,8 @@ UE
 UE
 gb
 sC
-zq
-tE
+pC
+go
 El
 El
 El
@@ -18212,7 +18367,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -18289,7 +18444,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -18300,9 +18455,9 @@ UE
 UE
 gs
 zq
-zq
 jM
-Oc
+Rg
+pY
 pY
 pY
 pY
@@ -18371,7 +18526,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -18448,7 +18603,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -18459,8 +18614,8 @@ UE
 UE
 gb
 nk
-zq
-jM
+tL
+jv
 pY
 kj
 EG
@@ -18530,7 +18685,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -18607,7 +18762,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -18689,7 +18844,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -18766,7 +18921,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -18848,7 +19003,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -18925,7 +19080,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -19007,7 +19162,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -19084,7 +19239,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -19166,7 +19321,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -19243,7 +19398,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -19325,7 +19480,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -19402,7 +19557,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -19484,7 +19639,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -19561,7 +19716,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 vu
@@ -19643,7 +19798,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -19720,7 +19875,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 Ca
@@ -19802,7 +19957,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -19879,7 +20034,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 Ca
@@ -19961,7 +20116,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -20038,7 +20193,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 Ca
@@ -20120,7 +20275,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -20197,7 +20352,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 Ca
@@ -20279,7 +20434,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -20356,7 +20511,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kt
 kt
@@ -20431,14 +20586,14 @@ WU
 kt
 kt
 kt
-kr
-kr
-kt
-KF
-KF
-KF
-KF
-KF
+sl
+sl
+tG
+Oc
+Oc
+Oc
+Oc
+Pb
 Ud
 QB
 kt
@@ -20515,7 +20670,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kr
 kr
@@ -20597,7 +20752,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 QB
 kt
@@ -20674,7 +20829,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kr
 kr
@@ -20756,7 +20911,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 kr
 kr
@@ -20833,7 +20988,7 @@ kt
 kt
 kt
 jN
-jN
+Jv
 kt
 kt
 kt
@@ -20915,7 +21070,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 Ud
 Ud
 Ud
@@ -20992,7 +21147,7 @@ KF
 KF
 KF
 QB
-QB
+dK
 KF
 KF
 KF
@@ -21074,60 +21229,60 @@ KF
 KF
 KF
 KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
-KF
+Es
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+RJ
 KF
 KF
 KF
@@ -21151,7 +21306,7 @@ KF
 KF
 KF
 QB
-QB
+dK
 KF
 KF
 KF
@@ -21286,7 +21441,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 KF
 KF
 KF
@@ -21310,7 +21465,7 @@ KF
 KF
 KF
 QB
-QB
+dK
 KF
 KF
 KF
@@ -21445,7 +21600,7 @@ KF
 KF
 KF
 KF
-KF
+tE
 KF
 KF
 KF
@@ -21469,7 +21624,7 @@ KF
 KF
 KF
 QB
-QB
+dK
 KF
 KF
 KF
@@ -21604,7 +21759,7 @@ KF
 KF
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -21628,7 +21783,7 @@ kt
 kt
 KF
 QB
-QB
+dK
 KF
 KF
 KF
@@ -21763,7 +21918,7 @@ KF
 KF
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -21787,7 +21942,7 @@ kt
 kt
 kt
 rI
-rI
+Fy
 kt
 kt
 kt
@@ -21922,7 +22077,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -21946,7 +22101,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -22081,7 +22236,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -22105,7 +22260,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -22240,7 +22395,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -22264,7 +22419,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -22399,7 +22554,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -22423,7 +22578,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -22558,7 +22713,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -22582,7 +22737,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -22717,7 +22872,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -22741,7 +22896,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -22876,7 +23031,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -22900,7 +23055,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -23035,7 +23190,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -23059,7 +23214,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kr
 kr
@@ -23194,7 +23349,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -23218,7 +23373,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kr
 kr
 kr
@@ -23353,7 +23508,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -23377,7 +23532,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -23512,7 +23667,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -23536,7 +23691,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -23671,7 +23826,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -23695,7 +23850,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -23830,7 +23985,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -23854,7 +24009,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -23989,7 +24144,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -24013,7 +24168,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -24148,7 +24303,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -24172,7 +24327,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -24307,7 +24462,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -24331,7 +24486,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -24466,7 +24621,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -24490,7 +24645,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -24625,7 +24780,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -24649,7 +24804,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -24784,7 +24939,7 @@ KF
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -24808,7 +24963,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -24943,13 +25098,13 @@ KF
 kt
 kt
 kt
+Tb
 kt
 kt
 kt
 kt
 kt
-kt
-kt
+tG
 kt
 kt
 kt
@@ -24967,7 +25122,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -25115,18 +25270,18 @@ kt
 kt
 kt
 kt
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 kt
 kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kr
-kr
+tG
+sl
+sg
 kt
 kt
 kt
@@ -25285,7 +25440,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -25444,7 +25599,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -25603,7 +25758,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -25762,7 +25917,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -25921,7 +26076,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -26080,7 +26235,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -26239,7 +26394,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -26398,7 +26553,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -26557,7 +26712,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -26716,7 +26871,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -26875,7 +27030,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -27034,7 +27189,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -27193,7 +27348,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -27352,7 +27507,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -27511,7 +27666,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -27670,7 +27825,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -27829,7 +27984,7 @@ kt
 kt
 kt
 kr
-kr
+QF
 kt
 kt
 kt
@@ -27988,13 +28143,13 @@ kt
 kt
 kt
 kr
-kr
-kt
-kt
-kt
-kt
-kt
-kt
+wM
+tG
+tG
+tG
+ca
+tG
+Nu
 kt
 kt
 kt
@@ -28151,7 +28306,7 @@ QB
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -28310,6 +28465,7 @@ QB
 KF
 KF
 KF
+tE
 KF
 KF
 KF
@@ -28327,7 +28483,7 @@ KF
 KF
 KF
 KF
-KF
+ko
 ko
 ko
 ko
@@ -28336,7 +28492,6 @@ ko
 ko
 rC
 QB
-KF
 KF
 kt
 kt
@@ -28469,7 +28624,7 @@ QB
 KF
 KF
 KF
-KF
+tE
 KF
 KF
 KF
@@ -28493,9 +28648,9 @@ PI
 PI
 PI
 ps
+ko
 rC
 QB
-KF
 KF
 iR
 iR
@@ -28628,7 +28783,7 @@ QB
 KF
 KF
 KF
-KF
+tE
 KF
 KF
 KF
@@ -28652,9 +28807,9 @@ PI
 PI
 PI
 PI
+kr
 rC
 QB
-KF
 KF
 iR
 iR
@@ -28787,7 +28942,7 @@ QB
 KF
 KF
 KF
-KF
+tE
 KF
 KF
 KF
@@ -28811,9 +28966,9 @@ PI
 PI
 PI
 PI
+kr
 rC
 QB
-KF
 KF
 iR
 iR
@@ -28946,7 +29101,7 @@ QB
 kt
 kt
 kt
-KF
+tE
 KF
 KF
 KF
@@ -28970,10 +29125,10 @@ PI
 PI
 PI
 PI
+kr
 rC
 QB
 kt
-Ud
 iR
 iR
 iR
@@ -29105,7 +29260,7 @@ kr
 kt
 kt
 kt
-KF
+tE
 KF
 KF
 kt
@@ -29129,9 +29284,9 @@ PI
 PI
 PI
 PI
+ko
 si
 kr
-jm
 jm
 iR
 iR
@@ -29264,7 +29419,7 @@ kr
 kt
 kt
 kt
-KF
+tE
 KF
 KF
 kt
@@ -29282,6 +29437,7 @@ kr
 kr
 kr
 kr
+ko
 ko
 ko
 ko
@@ -29290,7 +29446,6 @@ ko
 ko
 si
 kr
-jm
 jm
 iR
 iR
@@ -29423,7 +29578,7 @@ kr
 kt
 kt
 kt
-KF
+tE
 KF
 kt
 kt
@@ -29582,7 +29737,7 @@ kr
 kr
 kr
 QB
-QB
+dK
 QB
 QB
 QB
@@ -29741,7 +29896,7 @@ kr
 kr
 kr
 QB
-QB
+dK
 QB
 QB
 QB
@@ -29900,7 +30055,7 @@ kr
 kt
 kt
 kt
-KF
+tE
 KF
 KF
 kt
@@ -30059,7 +30214,7 @@ kr
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -30218,7 +30373,7 @@ kr
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -30377,7 +30532,7 @@ kr
 kt
 kt
 kt
-kt
+aw
 kt
 kt
 kt
@@ -31011,8 +31166,8 @@ kt
 kt
 kt
 kt
-kt
-kt
+tG
+tG
 kt
 kt
 kt
@@ -31276,7 +31431,7 @@ OX
 nq
 Jh
 Jh
-QF
+OX
 OX
 kt
 kt

--- a/maps/fairpoint/fairpoint-1.dmm
+++ b/maps/fairpoint/fairpoint-1.dmm
@@ -3,12 +3,6 @@
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/morgue)
-"aw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "az" = (
 /obj/structure/morgue{
 	dir = 4
@@ -24,10 +18,6 @@
 "aX" = (
 /obj/effect/floor_decal/floordetail/tiled,
 /turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
-"bd" = (
-/obj/structure/catwalk,
-/turf/simulated/floor,
 /area/fairpoint/maintenance/arrivals)
 "bf" = (
 /obj/machinery/camera/network/medbay,
@@ -55,12 +45,6 @@
 "bD" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/morgue)
-"ca" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "cb" = (
 /obj/effect/floor_decal/corner/blue/border,
 /obj/effect/floor_decal/corner/blue/border{
@@ -100,11 +84,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/maintenance/arrivals)
-"cY" = (
-/obj/effect/catwalk_plated,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/fairpoint/maintenance/arrivals)
 "df" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -130,12 +109,6 @@
 	color = "FFFEFD"
 	},
 /area/fairpoint/medical/exam_room)
-"dK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "dN" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 8
@@ -287,13 +260,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
-"jG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "jI" = (
 /obj/effect/floor_decal/corner/lightgrey/border{
 	tag = "icon-bordercolor (WEST)";
@@ -380,13 +346,6 @@
 /obj/machinery/door/blast/regular,
 /turf/simulated/floor/plating,
 /area/fairpoint/maintenance/arrivals)
-"lF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "lW" = (
 /obj/structure/closet/secure_closet/freezer{
 	name = "blood storage"
@@ -458,12 +417,6 @@
 "nq" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/sewer_exit)
-"nD" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "nP" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -573,20 +526,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
-"sg" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "si" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
-"sl" = (
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "sC" = (
@@ -630,16 +573,6 @@
 "tD" = (
 /turf/exterior/water,
 /area/fairpoint/maintenance/arrivals)
-"tE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
-"tG" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "tL" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
@@ -663,11 +596,6 @@
 	color = "#FFFEFD"
 	},
 /area/fairpoint/medical/morgue)
-"uf" = (
-/obj/structure/catwalk,
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "ul" = (
 /obj/machinery/door/airlock/glass/medical,
 /turf/simulated/floor/tiled/white,
@@ -677,11 +605,6 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/hallway/secondary/exit)
 "uB" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/corner/paleblue/full{
 	tag = "icon-corner_white_full (EAST)";
 	dir = 4
@@ -729,13 +652,6 @@
 /obj/item/chems/ivbag/blood/OMinus,
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
-"wM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "xa" = (
 /obj/structure/morgue,
 /obj/structure/window/reinforced{
@@ -758,10 +674,6 @@
 /obj/effect/floor_decal/corner/white/border,
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
-"xG" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/fairpoint/maintenance/arrivals)
 "yh" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /turf/simulated/floor/tiled/white,
@@ -929,13 +841,6 @@
 "El" = (
 /turf/simulated/floor/plating,
 /area/turbolift/hospital_sewers)
-"Es" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "Ev" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/white,
@@ -964,21 +869,10 @@
 /area/turbolift/metro_maintenance)
 "Ft" = (
 /obj/effect/catwalk_plated,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/fairpoint/hallway/secondary/exit)
 "Fw" = (
 /turf/simulated/floor,
-/area/fairpoint/maintenance/arrivals)
-"Fy" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	tag = "icon-bordercolor (WEST)";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_ridged,
 /area/fairpoint/maintenance/arrivals)
 "Ga" = (
 /obj/machinery/door/airlock/hatch/maintenance,
@@ -1046,10 +940,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
-"Hw" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "HS" = (
 /obj/machinery/door/airlock/hatch/maintenance,
 /turf/simulated/floor/tiled/techmaint,
@@ -1085,11 +975,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/hallway/secondary/exit)
-"IB" = (
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "Ja" = (
 /turf/simulated/wall/iron,
 /area/fairpoint/street/outskirts)
@@ -1111,16 +996,6 @@
 /obj/effect/floor_decal/corner/lightgrey/border,
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/hallway/secondary/exit)
-"Jv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	tag = "icon-bordercolor (WEST)";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "JE" = (
 /obj/structure/morgue{
 	dir = 8
@@ -1187,7 +1062,6 @@
 /area/fairpoint/maintenance/hospital)
 "LU" = (
 /obj/effect/floor_decal/floordetail/pryhole,
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "Mm" = (
@@ -1214,16 +1088,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/morgue)
-"Nu" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
-"NL" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "NN" = (
 /turf/simulated/wall/elevator,
 /area/fairpoint/maintenance/arrivals)
@@ -1232,14 +1096,8 @@
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
 "Oc" = (
-/obj/structure/disposalpipe/segment,
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
-"Ol" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
+/turf/simulated/wall/concrete,
+/area/turbolift/sewer_exit/mining)
 "Oq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/trash,
@@ -1253,12 +1111,6 @@
 "OX" = (
 /turf/simulated/wall/iron,
 /area/turbolift/sewer_exit)
-"Pb" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "Pn" = (
 /obj/structure/lift/button,
 /turf/simulated/wall/concrete,
@@ -1295,12 +1147,6 @@
 /area/fairpoint/medical/ward)
 "QB" = (
 /turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
-"QF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "QN" = (
 /obj/structure/closet/secure_closet/freezer{
@@ -1361,13 +1207,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/hallway/secondary/exit)
-"RJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "RQ" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer,
@@ -1403,17 +1242,8 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/maintenance/arrivals)
 "SW" = (
-/obj/structure/catwalk,
 /obj/effect/catwalk_plated,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/fairpoint/maintenance/arrivals)
-"Tb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/iron,
 /area/fairpoint/maintenance/arrivals)
 "Ti" = (
 /obj/effect/floor_decal/industrial/warning/dust,
@@ -1460,21 +1290,6 @@
 "UM" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/hallway/secondary/exit)
-"UP" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1;
-	tag = "icon-warning_dust (NORTH)"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
-"Vd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "Vk" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled,
@@ -1519,10 +1334,6 @@
 /obj/item/chems/ivbag/blood/OPlus,
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
-"WU" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "Xh" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -1563,13 +1374,6 @@
 	color = "FFFEFD"
 	},
 /area/fairpoint/medical/morgue)
-"XN" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "XR" = (
 /obj/structure/table/reinforced,
 /obj/item/scanner/autopsy,
@@ -6272,93 +6076,93 @@ Ud
 kp
 Ud
 lv
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
 SW
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
 Ft
 GK
 jI
@@ -6378,30 +6182,30 @@ ms
 jI
 cb
 Ft
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
-cY
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
+SW
 lv
 Ud
 kp
@@ -9011,8 +8815,8 @@ kt
 kt
 kt
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -9170,8 +8974,8 @@ kt
 Fw
 Fw
 Fw
-bd
-bd
+Fw
+Fw
 Fw
 Fw
 Fw
@@ -9316,9 +9120,9 @@ kt
 kt
 kt
 kt
-It
 kt
-It
+kt
+kt
 kt
 kt
 kt
@@ -9329,8 +9133,8 @@ kt
 Fw
 Fw
 Fw
-bd
-bd
+Fw
+Fw
 Fw
 Fw
 Fw
@@ -9460,10 +9264,10 @@ kt
 kt
 kt
 kt
-tG
-tG
-tG
-tG
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -9623,19 +9427,19 @@ kt
 kt
 kt
 kt
-aw
-kt
-It
-It
 kt
 kt
 kt
 kt
-It
 kt
 kt
 kt
-It
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -9782,17 +9586,17 @@ kt
 kt
 kt
 kt
-aw
-kt
-kt
-It
 kt
 kt
 kt
-It
 kt
 kt
-It
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -9941,7 +9745,7 @@ kt
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -10100,14 +9904,14 @@ kt
 kt
 kt
 kt
-aw
 kt
 kt
 kt
 kt
 kt
 kt
-It
+kt
+kt
 kt
 kt
 kt
@@ -10259,11 +10063,11 @@ kt
 kt
 kt
 kt
-aw
 kt
 kt
 kt
-It
+kt
+kt
 kt
 kt
 kt
@@ -10418,11 +10222,6 @@ kt
 kt
 kt
 kt
-aw
-kt
-kt
-kt
-It
 kt
 kt
 kt
@@ -10432,7 +10231,12 @@ kt
 kt
 kt
 kt
-It
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -10577,7 +10381,7 @@ kt
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -10727,15 +10531,15 @@ kr
 kr
 kt
 kt
-Vd
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
 Xh
 kt
 kt
@@ -10886,7 +10690,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kr
@@ -10915,16 +10719,16 @@ kr
 kr
 kr
 kr
-WU
-Hw
+kr
 QB
 QB
 QB
 QB
 QB
 QB
-Hw
-WU
+QB
+QB
+kr
 kr
 kr
 kt
@@ -11045,7 +10849,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kr
@@ -11074,16 +10878,16 @@ kr
 kr
 kr
 kr
-WU
-Hw
+kr
 QB
 QB
 QB
 QB
 QB
 QB
-Hw
-WU
+QB
+QB
+kr
 kr
 kr
 kt
@@ -11204,7 +11008,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -11363,7 +11167,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -11522,7 +11326,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -11681,7 +11485,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -11840,7 +11644,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -11848,55 +11652,55 @@ KF
 KF
 KF
 KF
-lF
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-tG
-NL
-NL
-tG
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-NL
-NL
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-NL
-NL
-Oc
-Oc
-Oc
-Oc
-Oc
-RJ
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+kt
+QB
+QB
+kt
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+QB
+QB
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+QB
+QB
+KF
+KF
+KF
+KF
+KF
+KF
 KF
 KF
 KF
@@ -11999,7 +11803,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -12007,7 +11811,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 KF
 KF
 KF
@@ -12055,7 +11859,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 KF
 KF
 KF
@@ -12158,7 +11962,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -12166,7 +11970,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 Ud
 Ud
@@ -12214,7 +12018,7 @@ kt
 kt
 KF
 KF
-tE
+KF
 KF
 KF
 kt
@@ -12317,7 +12121,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -12325,7 +12129,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 kr
 kr
@@ -12373,36 +12177,36 @@ kt
 kt
 KF
 KF
-Es
-Oc
-Oc
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-tG
-sl
-jG
+KF
+KF
+KF
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kr
+kr
 kr
 kr
 kr
@@ -12476,7 +12280,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -12484,7 +12288,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -12561,7 +12365,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kr
 kr
@@ -12635,7 +12439,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -12643,7 +12447,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -12720,7 +12524,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 kt
@@ -12794,7 +12598,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -12802,7 +12606,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -12879,7 +12683,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -12953,7 +12757,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -12961,7 +12765,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -13038,7 +12842,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -13112,7 +12916,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -13120,7 +12924,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -13197,7 +13001,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -13271,7 +13075,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -13279,7 +13083,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -13356,7 +13160,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -13430,7 +13234,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -13438,7 +13242,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -13515,7 +13319,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -13589,7 +13393,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -13597,7 +13401,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -13674,7 +13478,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -13748,7 +13552,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -13756,7 +13560,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -13833,7 +13637,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -13907,7 +13711,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -13915,7 +13719,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -13992,7 +13796,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -14066,7 +13870,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -14074,7 +13878,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -14151,7 +13955,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -14225,7 +14029,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -14233,7 +14037,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -14310,7 +14114,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -14384,7 +14188,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -14392,7 +14196,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -14469,7 +14273,7 @@ KF
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -14543,7 +14347,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -14551,7 +14355,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -14628,7 +14432,7 @@ KF
 KF
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -14702,7 +14506,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -14710,7 +14514,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -14787,7 +14591,7 @@ KF
 KF
 KF
 QB
-QF
+kr
 kr
 kt
 ea
@@ -14861,58 +14665,58 @@ kr
 kr
 kt
 kt
-aw
-kr
-kr
-kt
-KF
-KF
-KF
-KF
-tE
-Ud
-QB
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
 kt
 kr
 kr
 kt
+KF
+KF
+KF
+KF
+KF
+Ud
+QB
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kr
+kr
+kt
 kt
 kt
 kt
@@ -14946,7 +14750,7 @@ QB
 QB
 QB
 QB
-QF
+kr
 kr
 kt
 ea
@@ -15020,58 +14824,58 @@ kr
 kr
 kt
 kt
-aw
-kr
-kr
-kt
-KF
-KF
-KF
-KF
-tE
-Ud
-QB
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
 kt
 kr
 kr
 kt
+KF
+KF
+KF
+KF
+KF
+Ud
+QB
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kr
+kr
+kt
 kt
 kt
 kt
@@ -15105,7 +14909,7 @@ QB
 QB
 QB
 QB
-QF
+kr
 kr
 kt
 ea
@@ -15179,58 +14983,58 @@ kr
 kr
 kt
 kt
-aw
-kr
-kr
-kt
-KF
-KF
-KF
-KF
-tE
-Ud
-QB
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
-kt
 kt
 kr
 kr
 kt
+KF
+KF
+KF
+KF
+KF
+Ud
+QB
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kr
+kr
+kt
 kt
 kt
 kt
@@ -15264,7 +15068,7 @@ QB
 QB
 QB
 QB
-QF
+kr
 kr
 kt
 ea
@@ -15338,7 +15142,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -15346,7 +15150,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -15423,7 +15227,7 @@ KF
 KF
 KF
 QB
-QF
+kr
 kr
 kt
 ea
@@ -15497,7 +15301,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -15505,7 +15309,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -15582,7 +15386,7 @@ KF
 KF
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -15656,7 +15460,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -15664,7 +15468,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -15741,7 +15545,7 @@ KF
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -15815,7 +15619,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -15823,7 +15627,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -15900,7 +15704,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -15974,7 +15778,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -15982,7 +15786,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -16059,7 +15863,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -16133,7 +15937,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -16141,7 +15945,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -16218,7 +16022,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -16292,7 +16096,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -16300,7 +16104,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -16377,7 +16181,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -16451,7 +16255,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -16459,7 +16263,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -16536,7 +16340,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -16610,7 +16414,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -16618,7 +16422,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -16695,7 +16499,7 @@ kt
 kt
 kt
 kr
-XN
+kr
 kr
 kt
 ea
@@ -16769,7 +16573,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -16777,7 +16581,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -16854,7 +16658,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -16928,7 +16732,7 @@ kr
 kr
 kt
 kt
-aw
+kt
 kr
 kr
 kt
@@ -16936,7 +16740,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -17013,7 +16817,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 ea
@@ -17087,7 +16891,7 @@ kr
 Si
 kt
 kt
-aw
+kt
 GD
 kr
 kt
@@ -17095,7 +16899,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -17172,7 +16976,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -17246,7 +17050,7 @@ kr
 Si
 kt
 kt
-aw
+kt
 GD
 kr
 kt
@@ -17254,7 +17058,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -17331,7 +17135,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -17406,14 +17210,14 @@ Si
 ZG
 kr
 yR
-UP
-sl
-tG
-Oc
-Oc
-Oc
-Oc
-nD
+GD
+kr
+kt
+KF
+KF
+KF
+KF
+KF
 Ud
 QB
 kt
@@ -17490,7 +17294,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -17572,7 +17376,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -17649,7 +17453,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -17731,7 +17535,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -17808,7 +17612,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -17890,7 +17694,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -17967,7 +17771,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -18049,7 +17853,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -18126,7 +17930,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -18208,7 +18012,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -18285,7 +18089,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -18367,7 +18171,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -18444,7 +18248,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -18526,7 +18330,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -18603,7 +18407,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -18685,7 +18489,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -18762,7 +18566,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -18844,7 +18648,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -18921,7 +18725,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -19003,7 +18807,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -19080,7 +18884,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -19162,7 +18966,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -19239,7 +19043,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -19321,7 +19125,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -19398,7 +19202,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -19480,7 +19284,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -19557,7 +19361,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -19639,7 +19443,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -19716,7 +19520,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 vu
@@ -19786,8 +19590,8 @@ iR
 iR
 AM
 kt
-WU
-IB
+kr
+Si
 kt
 kt
 kt
@@ -19798,7 +19602,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -19875,7 +19679,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 Ca
@@ -19945,8 +19749,8 @@ iR
 iR
 AM
 kt
-WU
-IB
+kr
+Si
 ZG
 kr
 ZG
@@ -19957,7 +19761,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -20034,7 +19838,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 Ca
@@ -20104,8 +19908,8 @@ iR
 iR
 AM
 kt
-WU
-IB
+kr
+Si
 kt
 kt
 kt
@@ -20116,7 +19920,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -20193,7 +19997,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 Ca
@@ -20263,8 +20067,8 @@ iR
 iR
 AM
 kt
-WU
-IB
+kr
+Si
 kt
 kt
 kt
@@ -20275,7 +20079,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -20352,7 +20156,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 Ca
@@ -20422,8 +20226,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -20434,7 +20238,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -20511,7 +20315,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kt
 kt
@@ -20581,19 +20385,19 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
-sl
-sl
-tG
-Oc
-Oc
-Oc
-Oc
-Pb
+kr
+kr
+kt
+KF
+KF
+KF
+KF
+KF
 Ud
 QB
 kt
@@ -20670,7 +20474,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kr
 kr
@@ -20740,8 +20544,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -20752,7 +20556,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 QB
 kt
@@ -20829,7 +20633,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kr
 kr
@@ -20899,8 +20703,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -20911,7 +20715,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 kr
 kr
@@ -20988,7 +20792,7 @@ kt
 kt
 kt
 jN
-Jv
+jN
 kt
 kt
 kt
@@ -21058,8 +20862,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -21070,7 +20874,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 Ud
 Ud
 Ud
@@ -21147,7 +20951,7 @@ KF
 KF
 KF
 QB
-dK
+QB
 KF
 KF
 KF
@@ -21217,8 +21021,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -21229,60 +21033,60 @@ KF
 KF
 KF
 KF
-Es
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-Oc
-RJ
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
+KF
 KF
 KF
 KF
@@ -21306,7 +21110,7 @@ KF
 KF
 KF
 QB
-dK
+QB
 KF
 KF
 KF
@@ -21376,8 +21180,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -21441,7 +21245,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 KF
 KF
 KF
@@ -21465,7 +21269,7 @@ KF
 KF
 KF
 QB
-dK
+QB
 KF
 KF
 KF
@@ -21535,8 +21339,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -21600,7 +21404,7 @@ KF
 KF
 KF
 KF
-tE
+KF
 KF
 KF
 KF
@@ -21624,7 +21428,7 @@ KF
 KF
 KF
 QB
-dK
+QB
 KF
 KF
 KF
@@ -21694,8 +21498,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -21759,7 +21563,7 @@ KF
 KF
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -21783,7 +21587,7 @@ kt
 kt
 KF
 QB
-dK
+QB
 KF
 KF
 KF
@@ -21853,8 +21657,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -21918,7 +21722,7 @@ KF
 KF
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -21942,7 +21746,7 @@ kt
 kt
 kt
 rI
-Fy
+rI
 kt
 kt
 kt
@@ -22012,8 +21816,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -22077,7 +21881,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -22101,7 +21905,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -22171,8 +21975,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -22236,7 +22040,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -22260,7 +22064,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -22330,8 +22134,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -22395,7 +22199,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -22419,7 +22223,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -22489,8 +22293,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -22554,7 +22358,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -22578,7 +22382,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -22648,8 +22452,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -22713,7 +22517,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -22737,7 +22541,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -22807,8 +22611,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -22872,7 +22676,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -22896,7 +22700,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -22966,8 +22770,8 @@ iR
 iR
 AM
 kt
-WU
-xG
+kr
+Ud
 kt
 kt
 KF
@@ -23031,7 +22835,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -23055,7 +22859,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -23125,8 +22929,8 @@ iR
 iR
 AM
 kt
-WU
-xG
+kr
+Ud
 Ud
 QB
 QB
@@ -23190,7 +22994,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -23214,7 +23018,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kr
 kr
@@ -23284,8 +23088,8 @@ iR
 iR
 AM
 kt
-WU
-xG
+kr
+Ud
 Ud
 QB
 QB
@@ -23349,7 +23153,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -23373,7 +23177,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kr
 kr
 kr
@@ -23443,8 +23247,8 @@ iR
 iR
 AM
 kt
-WU
-xG
+kr
+Ud
 kt
 kt
 KF
@@ -23508,7 +23312,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -23532,7 +23336,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -23602,8 +23406,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -23667,7 +23471,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -23691,7 +23495,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -23761,8 +23565,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -23826,7 +23630,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -23850,7 +23654,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -23920,8 +23724,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -23985,7 +23789,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -24009,7 +23813,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -24079,8 +23883,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -24144,7 +23948,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -24168,7 +23972,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -24238,8 +24042,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -24303,7 +24107,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -24327,7 +24131,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -24397,8 +24201,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -24462,7 +24266,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -24486,7 +24290,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -24556,8 +24360,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -24621,7 +24425,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -24645,7 +24449,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -24715,8 +24519,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -24780,7 +24584,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -24804,7 +24608,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -24874,23 +24678,6 @@ iR
 iR
 AM
 kt
-WU
-WU
-kt
-kt
-KF
-KF
-KF
-KF
-KF
-KF
-kt
-kt
-kr
-kr
-kr
-kr
-kr
 kr
 kr
 kt
@@ -24898,6 +24685,23 @@ kt
 KF
 KF
 KF
+KF
+KF
+KF
+kt
+kt
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kt
+kt
+KF
+KF
+KF
 kt
 kt
 kt
@@ -24939,7 +24743,7 @@ KF
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -24963,7 +24767,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -25033,8 +24837,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 KF
@@ -25098,13 +24902,13 @@ KF
 kt
 kt
 kt
-Tb
 kt
 kt
 kt
 kt
 kt
-tG
+kt
+kt
 kt
 kt
 kt
@@ -25122,7 +24926,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -25192,8 +24996,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -25270,18 +25074,18 @@ kt
 kt
 kt
 kt
-tG
-tG
-tG
-tG
-tG
-tG
-tG
 kt
 kt
-tG
-sl
-sg
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kr
+kr
 kt
 kt
 kt
@@ -25351,8 +25155,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -25440,7 +25244,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -25510,8 +25314,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -25599,7 +25403,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -25669,8 +25473,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -25758,7 +25562,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -25828,8 +25632,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -25917,7 +25721,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -25987,8 +25791,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -26076,7 +25880,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -26146,8 +25950,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -26235,7 +26039,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -26305,8 +26109,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -26394,7 +26198,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -26464,8 +26268,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -26553,7 +26357,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -26623,8 +26427,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -26712,7 +26516,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -26782,8 +26586,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -26871,7 +26675,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -26941,8 +26745,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -27030,7 +26834,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -27100,8 +26904,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -27189,7 +26993,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -27259,8 +27063,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -27348,7 +27152,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -27418,8 +27222,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -27507,7 +27311,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -27577,8 +27381,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -27666,7 +27470,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -27736,8 +27540,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -27825,7 +27629,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -27895,8 +27699,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -27984,7 +27788,7 @@ kt
 kt
 kt
 kr
-QF
+kr
 kt
 kt
 kt
@@ -28054,8 +27858,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -28143,13 +27947,13 @@ kt
 kt
 kt
 kr
-wM
-tG
-tG
-tG
-ca
-tG
-Nu
+kr
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -28213,8 +28017,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -28306,7 +28110,7 @@ QB
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -28372,8 +28176,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 cm
@@ -28465,7 +28269,6 @@ QB
 KF
 KF
 KF
-tE
 KF
 KF
 KF
@@ -28483,13 +28286,14 @@ KF
 KF
 KF
 KF
-ko
-ko
-ko
-ko
-ko
-ko
-ko
+KF
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
 rC
 QB
 KF
@@ -28531,8 +28335,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -28624,7 +28428,6 @@ QB
 KF
 KF
 KF
-tE
 KF
 KF
 KF
@@ -28642,13 +28445,14 @@ KF
 KF
 KF
 KF
-ko
+KF
+Oc
 PI
 PI
 PI
 PI
 ps
-ko
+Oc
 rC
 QB
 KF
@@ -28690,8 +28494,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -28783,7 +28587,6 @@ QB
 KF
 KF
 KF
-tE
 KF
 KF
 KF
@@ -28801,13 +28604,14 @@ KF
 KF
 KF
 KF
-ko
+KF
+Oc
 PI
 PI
 PI
 PI
 PI
-kr
+PI
 rC
 QB
 KF
@@ -28849,8 +28653,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -28942,7 +28746,6 @@ QB
 KF
 KF
 KF
-tE
 KF
 KF
 KF
@@ -28960,13 +28763,14 @@ KF
 KF
 KF
 KF
-ko
+KF
+Oc
 PI
 PI
 PI
 PI
 PI
-kr
+PI
 rC
 QB
 KF
@@ -29008,8 +28812,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -29101,10 +28905,10 @@ QB
 kt
 kt
 kt
-tE
 KF
 KF
 KF
+KF
 kt
 kt
 kt
@@ -29119,13 +28923,13 @@ kt
 kt
 kt
 kt
-ko
+Oc
 PI
 PI
 PI
 PI
 PI
-kr
+PI
 rC
 QB
 kt
@@ -29167,8 +28971,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -29260,9 +29064,9 @@ kr
 kt
 kt
 kt
-tE
 KF
 KF
+KF
 kt
 kt
 kt
@@ -29278,13 +29082,13 @@ kt
 kt
 kt
 kt
-ko
+Oc
 PI
 PI
 PI
 PI
 PI
-ko
+Oc
 si
 kr
 jm
@@ -29326,8 +29130,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -29419,7 +29223,7 @@ kr
 kt
 kt
 kt
-tE
+KF
 KF
 KF
 kt
@@ -29437,13 +29241,13 @@ kr
 kr
 kr
 kr
-ko
-ko
-ko
-ko
-ko
-ko
-ko
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
+Oc
 si
 kr
 jm
@@ -29485,8 +29289,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -29578,7 +29382,7 @@ kr
 kt
 kt
 kt
-tE
+KF
 KF
 kt
 kt
@@ -29644,8 +29448,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -29737,7 +29541,7 @@ kr
 kr
 kr
 QB
-dK
+QB
 QB
 QB
 QB
@@ -29803,8 +29607,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -29896,7 +29700,7 @@ kr
 kr
 kr
 QB
-dK
+QB
 QB
 QB
 QB
@@ -29962,8 +29766,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -30055,7 +29859,7 @@ kr
 kt
 kt
 kt
-tE
+KF
 KF
 KF
 kt
@@ -30121,8 +29925,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -30214,7 +30018,7 @@ kr
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -30280,8 +30084,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -30373,7 +30177,7 @@ kr
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -30439,8 +30243,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -30532,7 +30336,7 @@ kr
 kt
 kt
 kt
-aw
+kt
 kt
 kt
 kt
@@ -30598,8 +30402,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -30656,9 +30460,9 @@ kr
 kt
 kt
 kt
-It
 kt
-It
+kt
+kt
 kt
 kt
 kt
@@ -30757,8 +30561,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -30814,20 +30618,20 @@ kr
 kr
 kt
 kt
-It
-It
 kt
 kt
 kt
 kt
 kt
-It
 kt
 kt
 kt
 kt
 kt
-It
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -30916,8 +30720,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -30974,7 +30778,6 @@ kr
 kt
 kt
 kt
-It
 kt
 kt
 kt
@@ -30984,20 +30787,21 @@ kt
 kt
 kt
 kt
-It
-kt
-It
 kt
 kt
 kt
 kt
 kt
-It
-It
-It
-It
-It
-It
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -31075,8 +30879,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -31145,18 +30949,6 @@ kt
 kt
 kt
 kt
-It
-kt
-kt
-kt
-kt
-kt
-It
-It
-It
-It
-It
-It
 kt
 kt
 kt
@@ -31166,8 +30958,20 @@ kt
 kt
 kt
 kt
-tG
-tG
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -31234,8 +31038,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -31289,12 +31093,6 @@ kt
 kt
 kr
 Oq
-It
-It
-It
-It
-kt
-It
 kt
 kt
 kt
@@ -31304,18 +31102,24 @@ kt
 kt
 kt
 kt
-It
 kt
 kt
 kt
 kt
 kt
-It
-It
-It
-It
-It
-It
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -31393,8 +31197,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -31448,33 +31252,33 @@ kt
 kt
 kr
 AS
-It
-It
-It
-It
-kt
-It
-kt
-kt
-It
-It
-It
-kt
-It
-kt
-kt
-It
 kt
 kt
 kt
 kt
 kt
-It
-It
-It
-It
-It
-It
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -31552,8 +31356,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 ZG
 kr
 kr
@@ -31616,24 +31420,24 @@ kt
 kt
 kt
 kt
-It
-It
-kt
-kt
-kt
-kt
-It
 kt
 kt
 kt
 kt
 kt
-It
-It
-It
-It
-It
-It
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
+kt
 kt
 kt
 kt
@@ -31711,8 +31515,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 ZG
 kr
 kr
@@ -31870,8 +31674,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -32029,8 +31833,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -32188,8 +31992,8 @@ iR
 iR
 AM
 kt
-WU
-WU
+kr
+kr
 kt
 kt
 kt
@@ -32349,36 +32153,7 @@ AM
 kt
 kr
 kr
-uf
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
+ZG
 kr
 kr
 kr
@@ -32390,19 +32165,48 @@ kr
 kr
 kr
 kr
-WU
-WU
-WU
-WU
-WU
-WU
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
 aX
 aX
 Ti
 kr
 kr
 AS
-Ol
+kt
 kt
 kt
 kt
@@ -32508,52 +32312,52 @@ AM
 kt
 kr
 kr
-uf
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
-WU
+ZG
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
+kr
 LU
 aX
 aX

--- a/maps/fairpoint/fairpoint-2.dmm
+++ b/maps/fairpoint/fairpoint-2.dmm
@@ -3544,11 +3544,9 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/crew_quarters/kitchen)
 "fia" = (
-/obj/structure/sign/warning,
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/turbolift/hospital_surface)
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "fjf" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/crew_quarters/sleep/cryo)
@@ -4991,7 +4989,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/street/north)
 "hpB" = (
-/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/turbolift/hospital_surface)
 "hpF" = (
@@ -5000,12 +4997,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/shipping/storage)
-"hpM" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/fairpoint/medical/exam_room)
 "hqc" = (
 /obj/effect/catwalk_plated,
 /turf/simulated/floor/plating,
@@ -5368,14 +5359,6 @@
 "hTM" = (
 /turf/simulated/floor/tiled,
 /area/fairpoint/science/rd)
-"hTT" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/structure/railing/mapped,
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_surface)
 "hUi" = (
 /obj/structure/sign/warning/nosmoking_2,
 /turf/simulated/wall/concrete,
@@ -5785,9 +5768,8 @@
 "iEt" = (
 /obj/effect/floor_decal/corner/paleblue,
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_surface)
+/area/fairpoint/medical/medbay)
 "iEx" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/corner/pink/diagonal,
@@ -6139,10 +6121,6 @@
 /obj/structure/table/woodentable/ebony,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/fairpoint/crew_quarters/bar)
-"jaR" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/tiled,
-/area/fairpoint/hallway/secondary/exit)
 "jbq" = (
 /turf/simulated/wall/concrete,
 /area/fairpoint/research/lab)
@@ -6777,9 +6755,8 @@
 /turf/simulated/floor/wood,
 /area/fairpoint/crew_quarters/fitness)
 "kfr" = (
-/obj/structure/table/woodentable,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/wall/elevator,
 /area/turbolift/sewer_entrance)
 "kfK" = (
 /obj/effect/floor_decal/corner/paleblue,
@@ -8200,7 +8177,7 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/surgeryobs)
 "mbO" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/sewer_entrance)
 "mca" = (
 /obj/machinery/button/blast_door{
@@ -9424,7 +9401,7 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/crew_quarters/kitchen)
 "nTq" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/metro_station)
 "nTU" = (
 /turf/simulated/wall/concrete,
@@ -9508,7 +9485,7 @@
 /turf/simulated/floor/plating,
 /area/fairpoint/street/east)
 "ocy" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/hospital_surface)
 "odj" = (
 /obj/item/beach_ball/holoball,
@@ -9739,9 +9716,8 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/hydroponics)
 "otU" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/concrete,
-/area/fairpoint/street/east)
+/turf/simulated/floor/tiled/dark,
+/area/turbolift/pd_ground)
 "ouU" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
@@ -10342,7 +10318,7 @@
 /turf/simulated/wall/concrete,
 /area/fairpoint/police/brig/interrogation)
 "pkH" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/fairpoint/street/east)
 "plq" = (
 /obj/machinery/vending/coffee,
@@ -11041,9 +11017,11 @@
 /turf/exterior/water,
 /area/fairpoint/street/west)
 "qfx" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/concrete,
-/area/turbolift/metro_station)
+/obj/machinery/vending/games{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/fairpoint/hallway/secondary/exit)
 "qfP" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/white{
@@ -11658,6 +11636,9 @@
 /area/fairpoint/police/brig)
 "qYB" = (
 /obj/structure/table/steel,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
 /obj/item/mop,
 /turf/simulated/floor/tiled,
 /area/fairpoint/janitor)
@@ -11702,7 +11683,6 @@
 /turf/simulated/floor/beach/water,
 /area/fairpoint/law)
 "rdJ" = (
-/obj/structure/lift/button,
 /turf/simulated/wall/concrete,
 /area/turbolift/metro_station)
 "rdT" = (
@@ -15332,13 +15312,6 @@
 /obj/item/storage/box/cups,
 /turf/simulated/floor/tiled/monotile,
 /area/fairpoint/cityhall)
-"wjj" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_ground)
 "wkn" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/white{
@@ -15721,14 +15694,6 @@
 /obj/structure/closet/crate/trashcart,
 /turf/exterior/concrete/pavement/empty,
 /area/fairpoint/street)
-"wHH" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_surface)
 "wHK" = (
 /obj/structure/window/reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -15812,9 +15777,9 @@
 /area/fairpoint/cityhall)
 "wLZ" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 8
 	},
-/obj/structure/railing/mapped,
+/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "wOg" = (
@@ -15959,9 +15924,14 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/shipping/office)
 "wZC" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel_grid,
-/area/turbolift/sewer_entrance)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "wZG" = (
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 1
@@ -22797,7 +22767,7 @@ rdJ
 cAk
 cAk
 cAk
-qfx
+rdJ
 fhi
 fhi
 wEM
@@ -22952,7 +22922,7 @@ fpv
 fpv
 fpv
 nTU
-jaR
+dsM
 tJW
 tJW
 tJW
@@ -23432,7 +23402,7 @@ nTU
 lJr
 tJW
 tJW
-dsM
+qfx
 jCq
 jDL
 tqN
@@ -29068,7 +29038,7 @@ uMb
 uMb
 uMb
 dtN
-wjj
+gnW
 mof
 iaK
 pkf
@@ -29221,12 +29191,12 @@ rML
 rML
 pWB
 rPk
-uMb
 mqf
 mqf
 lVO
 lVO
 vVS
+uMb
 bvd
 mof
 iaK
@@ -29380,12 +29350,12 @@ xfY
 rML
 pWB
 rPk
-uMb
 qDh
 qDh
 qDh
 qDh
 qDh
+otU
 gXH
 mof
 hep
@@ -29539,12 +29509,12 @@ xfY
 rML
 pWB
 rPk
-uMb
 uVf
 uVf
 uVf
 uVf
 uVf
+otU
 gXH
 mof
 mof
@@ -29698,12 +29668,12 @@ xfY
 rML
 uJE
 rPk
-uMb
 mqf
 mqf
 lVO
 mqf
 ttC
+otU
 gXH
 mof
 kUg
@@ -29857,12 +29827,12 @@ xfY
 rML
 pWB
 rPk
-uMb
 mqf
 mqf
 lVO
 lVO
 ttC
+uMb
 bvd
 mof
 iaK
@@ -32510,8 +32480,8 @@ xZb
 amd
 nSl
 kpd
-uJq
 sNO
+mLQ
 mLQ
 mLQ
 mLQ
@@ -32669,9 +32639,9 @@ whQ
 nMd
 xsH
 ugG
-uJq
-hTT
-fia
+aIb
+peD
+peD
 peD
 peD
 peD
@@ -32828,8 +32798,8 @@ qBI
 dSp
 hAI
 uJq
-uJq
-wHH
+wLZ
+peD
 ocy
 ocy
 ocy
@@ -32987,7 +32957,7 @@ ykh
 tdt
 xOf
 bUy
-uJq
+fia
 hpB
 ocy
 ocy
@@ -33146,7 +33116,7 @@ nAd
 xkl
 xsH
 yjp
-uJq
+fia
 hpB
 ocy
 ocy
@@ -33305,7 +33275,7 @@ vjM
 uwr
 xte
 swf
-uJq
+fia
 hpB
 ocy
 ocy
@@ -33464,8 +33434,8 @@ bOA
 fVY
 uwr
 ugG
-uJq
 iEt
+peD
 ocy
 ocy
 ocy
@@ -33623,9 +33593,9 @@ bOA
 dNA
 qQt
 uJq
-uJq
-wLZ
-hpM
+aIb
+dJK
+vDC
 vDC
 vDC
 vDC
@@ -33782,8 +33752,8 @@ bOA
 frg
 uwr
 bUy
-uJq
-aIb
+jqc
+wZC
 vDC
 nGf
 swT
@@ -43816,8 +43786,8 @@ pkH
 pkH
 pkH
 pkH
-otU
-nHY
+dWz
+mav
 nHY
 wCx
 wCx
@@ -43976,7 +43946,7 @@ pkH
 pkH
 pkH
 mav
-nHY
+mav
 nHY
 wCx
 wCx
@@ -44135,7 +44105,7 @@ pkH
 pkH
 pkH
 mav
-nHY
+mav
 nHY
 wCx
 wCx
@@ -44294,7 +44264,7 @@ pkH
 pkH
 pkH
 mav
-nHY
+mav
 nHY
 wCx
 wCx
@@ -44453,7 +44423,7 @@ pkH
 pkH
 pkH
 dWz
-nHY
+mav
 nHY
 wCx
 wCx
@@ -46595,7 +46565,7 @@ pFA
 sLB
 uCX
 knD
-wZC
+kfr
 doo
 doo
 doo

--- a/maps/fairpoint/fairpoint-2.dmm
+++ b/maps/fairpoint/fairpoint-2.dmm
@@ -1040,7 +1040,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "byL" = (
 /obj/structure/window/reinforced,
@@ -5224,7 +5224,7 @@
 /area/fairpoint/shipping/qm)
 "hQf" = (
 /obj/machinery/door/airlock/glass/civilian,
-/turf/simulated/floor/tiled/monofloor,
+/turf/exterior/concrete/pavement/brick_paving,
 /area/fairpoint/street)
 "hQg" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5535,7 +5535,7 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard West"
 	},
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police)
 "ioC" = (
 /obj/machinery/conveyor{
@@ -7116,7 +7116,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "kFH" = (
 /obj/structure/sign/neon/casino,
@@ -8091,7 +8091,7 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/surgeryobs)
 "mbO" = (
-/turf/unsimulated/mask,
+/turf/simulated/open,
 /area/turbolift/sewer_entrance)
 "mca" = (
 /obj/machinery/button/blast_door{
@@ -10751,7 +10751,7 @@
 /turf/exterior/concrete,
 /area/fairpoint/street/north)
 "pWB" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police)
 "pWN" = (
 /obj/effect/floor_decal/corner/blue/full{
@@ -11093,9 +11093,6 @@
 /area/fairpoint/hydroponics)
 "qrN" = (
 /obj/abstract/level_data/main_level,
-/obj/abstract/map_data{
-	height = 3
-	},
 /turf/simulated/wall/r_wall/hull,
 /area/fairpoint/street/west)
 "qrZ" = (
@@ -11481,9 +11478,6 @@
 /obj/structure/grille,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/crew_quarters/bar)
-"qVu" = (
-/turf/simulated/floor/tiled/monofloor,
-/area/fairpoint/street)
 "qVA" = (
 /obj/effect/floor_decal/beach{
 	dir = 4
@@ -13443,7 +13437,7 @@
 /area/fairpoint/maintenance/surface)
 "tDr" = (
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "tEe" = (
 /obj/structure/table/reinforced,
@@ -14185,7 +14179,7 @@
 /area/fairpoint/street/east)
 "uJE" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police)
 "uJY" = (
 /obj/structure/closet/secure_closet/personal/cabinet{
@@ -14501,7 +14495,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "vgF" = (
 /obj/effect/floor_decal/borderfloorwhite/corner{
@@ -19332,25 +19326,25 @@ fpv
 fpv
 fpv
 xAk
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
 tDr
 fhi
 nse
@@ -19505,11 +19499,11 @@ fpv
 dfi
 dfi
 dfi
-bOc
-bOc
+rHw
+rHw
 rKs
-bOc
-bOc
+rHw
+rHw
 ajS
 fhi
 nse
@@ -19664,11 +19658,11 @@ fpv
 dfi
 tfZ
 dfi
-bOc
-bOc
+rHw
+rHw
 kwZ
-bOc
-bOc
+rHw
+rHw
 ajS
 fhi
 nse
@@ -19823,11 +19817,11 @@ fpv
 dfi
 dfi
 dfi
-bOc
-bOc
+rHw
+rHw
 rKs
-bOc
-bOc
+rHw
+rHw
 ajS
 fhi
 nse
@@ -19968,25 +19962,25 @@ fpv
 fpv
 fpv
 eRp
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
 tDr
 fhi
 nse
@@ -20127,25 +20121,25 @@ fpv
 fpv
 fpv
 xAk
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
 tDr
 fhi
 nse
@@ -20300,11 +20294,11 @@ fpv
 fpv
 fpv
 fpv
-bOc
-bOc
+rHw
+rHw
 fpv
-bOc
-bOc
+rHw
+rHw
 grX
 fhi
 nse
@@ -20459,11 +20453,11 @@ mix
 mix
 mix
 mix
-bOc
-bOc
+rHw
+rHw
 uVi
-bOc
-bOc
+rHw
+rHw
 grX
 fhi
 nse
@@ -20618,11 +20612,11 @@ mix
 mix
 mix
 mix
-bOc
-bOc
+rHw
+rHw
 iWU
-bOc
-bOc
+rHw
+rHw
 grX
 fhi
 nse
@@ -20764,24 +20758,24 @@ wTG
 efX
 imx
 mix
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
 uVi
-bOc
-bOc
+rHw
+rHw
 grX
 fhi
 nse
@@ -20923,24 +20917,24 @@ vUV
 mtP
 imx
 uDW
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
-bOc
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
+rHw
 iWU
-bOc
-bOc
+rHw
+rHw
 grX
 fhi
 nse
@@ -21082,7 +21076,7 @@ vUV
 mtP
 imx
 mix
-bOc
+rHw
 mix
 cui
 mix
@@ -21095,8 +21089,8 @@ iWU
 iWU
 iWU
 iWU
-bOc
-bOc
+rHw
+rHw
 jpI
 qrZ
 rFA
@@ -21254,8 +21248,8 @@ vfI
 vfI
 vfI
 kFo
-bOc
-bOc
+rHw
+rHw
 byu
 vfI
 vfI
@@ -29480,7 +29474,7 @@ uMe
 hSS
 eQu
 eQu
-qVu
+ctl
 hQf
 ctl
 ctl
@@ -29639,7 +29633,7 @@ uMe
 hSS
 eQu
 eQu
-qVu
+ctl
 hQf
 ctl
 ctl

--- a/maps/fairpoint/fairpoint-2.dmm
+++ b/maps/fairpoint/fairpoint-2.dmm
@@ -158,16 +158,6 @@
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/fairpoint/engineering/storage)
-"anZ" = (
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	icon_state = "shutter0";
-	name = "Magistrate Shutters"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized,
-/turf/simulated/floor/tiled,
-/area/fairpoint/law/judge)
 "aos" = (
 /turf/exterior/concrete/pavement{
 	dir = 4
@@ -660,7 +650,7 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/computer/modular/preset/supply_public,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "bbc" = (
 /obj/effect/floor_decal/carpet/purple,
 /obj/effect/floor_decal/carpet/purple{
@@ -990,12 +980,6 @@
 	},
 /turf/exterior/concrete/reinforced/road,
 /area/fairpoint/street)
-"btj" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "btz" = (
 /obj/structure/janitorialcart,
 /turf/simulated/floor/tiled,
@@ -1373,7 +1357,7 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "cdn" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 9
@@ -1571,7 +1555,6 @@
 	icon_state = "shutter0";
 	name = "Magistrate Shutters"
 	},
-/obj/structure/grille,
 /obj/effect/wingrille_spawn/reinforced/polarized,
 /turf/simulated/floor/tiled,
 /area/fairpoint/law/judge)
@@ -1948,7 +1931,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -1956,6 +1938,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "cQT" = (
@@ -2034,11 +2017,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "cXZ" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "cYd" = (
 /obj/structure/bed/chair/wood/ebony,
 /turf/simulated/floor/wood/walnut,
@@ -2066,9 +2049,8 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/research/robotics)
 "daM" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/dark,
-/area/fairpoint/cityhall)
+/turf/simulated/wall/concrete,
+/area/turbolift/sewer_entrance/mining)
 "daZ" = (
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -2614,7 +2596,12 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/surgery)
 "dSC" = (
-/turf/space,
+/obj/turbolift_map_holder/fairpoint{
+	dir = 4;
+	lift_size_x = 3;
+	lift_size_y = 3
+	},
+/turf/simulated/floor/wood/usedup,
 /area/fairpoint/street/east)
 "dTc" = (
 /obj/effect/floor_decal/stoneborder{
@@ -2681,7 +2668,6 @@
 	icon_state = "shutter0";
 	name = "Magistrate Shutters"
 	},
-/obj/structure/grille,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/fairpoint/law/judge)
@@ -2827,7 +2813,6 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/research)
 "efI" = (
-/obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -2844,6 +2829,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/structure/grille,
 /turf/simulated/floor/tiled,
 /area/fairpoint/research/robotics)
 "efX" = (
@@ -2970,7 +2956,6 @@
 /area/fairpoint/science/rd)
 "erz" = (
 /obj/machinery/vending/snack,
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/cityhall)
 "esA" = (
@@ -3431,16 +3416,6 @@
 /obj/machinery/network/pager/cargo,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/shipping/office)
-"eYY" = (
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	icon_state = "shutter0";
-	name = "Prosecution Shutters"
-	},
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/tiled,
-/area/fairpoint/law/lawoffice)
 "eZa" = (
 /obj/structure/window/reinforced,
 /obj/machinery/deployable/barrier,
@@ -3620,7 +3595,7 @@
 	},
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "fnV" = (
 /obj/structure/railing,
 /turf/exterior/concrete/pavement/empty,
@@ -3957,16 +3932,6 @@
 	dir = 1
 	},
 /area/fairpoint/street/north)
-"fRO" = (
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	icon_state = "shutter0";
-	name = "Magistrate Shutters"
-	},
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/tiled,
-/area/fairpoint/law/judge)
 "fSh" = (
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/detectives_office)
@@ -4086,10 +4051,6 @@
 "gby" = (
 /turf/exterior/wall,
 /area/fairpoint/maintenance/surface)
-"gcI" = (
-/obj/structure/sign/warning,
-/turf/simulated/wall/wood,
-/area/fairpoint/street/east)
 "gdw" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -4257,26 +4218,6 @@
 "gsx" = (
 /turf/simulated/wall/concrete,
 /area/fairpoint/law/judge)
-"gsM" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact";
-	tag = "icon-intact-f (EAST)"
-	},
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/greengrid,
-/area/fairpoint/research/server)
 "gsN" = (
 /obj/structure/disposalpipe/segment,
 /turf/exterior/concrete/pavement/pave_tiling,
@@ -4330,7 +4271,6 @@
 	icon_state = "shutter0";
 	name = "Defense Shutters"
 	},
-/obj/structure/grille,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/fairpoint/law/lawoffice)
@@ -4531,9 +4471,6 @@
 /turf/simulated/floor/carpet,
 /area/fairpoint/law)
 "gKJ" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/random/trash,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1;
@@ -4766,7 +4703,6 @@
 	icon_state = "shutter0";
 	name = "Prosecution Shutters"
 	},
-/obj/structure/grille,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/fairpoint/law/lawoffice)
@@ -5082,15 +5018,6 @@
 	color = "FFFEFD"
 	},
 /area/fairpoint/medical/biostorage)
-"hzc" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "hzz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -5110,8 +5037,7 @@
 "hAI" = (
 /obj/machinery/holosign/surgery,
 /obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 1";
-	req_access = list(45)
+	name = "Operating Theatre 1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/surgery)
@@ -5465,7 +5391,7 @@
 "ica" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall/concrete,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "ict" = (
 /obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/simulated/floor/tiled,
@@ -6234,12 +6160,11 @@
 	},
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "jhD" = (
 /turf/exterior/concrete/road/garage,
 /area/fairpoint/police)
 "jiN" = (
-/obj/effect/wingrille_spawn/reinforced/polarized,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/meeting)
@@ -6505,7 +6430,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -6513,6 +6437,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "jMi" = (
@@ -7172,6 +7097,7 @@
 /obj/structure/window/reinforced/full{
 	color = "#CCCC7A"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/wood/usedup,
 /area/fairpoint/street/east)
 "kEz" = (
@@ -7319,7 +7245,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "kPA" = (
 /obj/structure/sign/neon/bathrooms,
 /turf/simulated/wall/concrete,
@@ -7447,12 +7373,6 @@
 	color = "#FFFEFD"
 	},
 /area/fairpoint/medical/sleeper)
-"kYj" = (
-/obj/turbolift_map_holder/fairpoint{
-	dir = 4
-	},
-/turf/space,
-/area/fairpoint/street/east)
 "kYl" = (
 /obj/machinery/door/airlock/medical{
 	name = "Emergency Room";
@@ -7894,7 +7814,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/sign/cargo,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "lEm" = (
 /obj/structure/bookcase{
 	name = "bookcase (Fiction)"
@@ -7944,7 +7864,7 @@
 "lGT" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "lHx" = (
 /obj/machinery/door/airlock/engineering{
 	req_access = list(1,32)
@@ -8007,12 +7927,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/police/brig/interrogation)
-"lSe" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "lSr" = (
 /obj/machinery/light/street,
 /turf/exterior/concrete/pavement/corner_invert,
@@ -8698,12 +8612,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/shipping/office)
-"mOf" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "mOr" = (
 /turf/exterior/concrete/pavement/corner{
 	dir = 1
@@ -9449,9 +9357,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/street/north)
 "nZl" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1;
 	tag = "icon-warning_dust (NORTH)"
@@ -10319,7 +10224,7 @@
 /area/fairpoint/police/brig/interrogation)
 "pkH" = (
 /turf/unsimulated/mask,
-/area/fairpoint/street/east)
+/area/turbolift/sewer_entrance/mining)
 "plq" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood/walnut,
@@ -10655,7 +10560,7 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "pKq" = (
 /obj/machinery/light_switch/on{
 	pixel_y = 24
@@ -10930,7 +10835,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "pZi" = (
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Jail Hallway East";
@@ -11327,15 +11232,8 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/surgery)
 "qCl" = (
-/obj/effect/wallframe_spawn/reinforced/bare,
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/fairpoint/shipping/storage)
+/turf/simulated/floor/tiled/dark,
+/area/fairpoint/shipping/office)
 "qCD" = (
 /obj/effect/floor_decal/corner/paleblue/border,
 /turf/simulated/floor/wood/usedup,
@@ -11580,6 +11478,7 @@
 /obj/structure/window/reinforced/full{
 	color = "#cc6699"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/crew_quarters/bar)
 "qVu" = (
@@ -12079,7 +11978,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -12087,6 +11985,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "rHw" = (
@@ -12133,12 +12032,6 @@
 /obj/effect/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/fairpoint/police/brig/interrogation)
-"rLp" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/exterior/concrete/pavement/empty,
-/area/fairpoint/street/west)
 "rLq" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
@@ -12364,7 +12257,7 @@
 "rYd" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "rYg" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/cobweb2,
@@ -12571,6 +12464,7 @@
 /obj/structure/window/reinforced/full{
 	color = "#CCCC7A"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/street/east)
 "smK" = (
@@ -12594,19 +12488,6 @@
 /obj/item/taperecorder,
 /turf/simulated/floor/carpet,
 /area/fairpoint/law/lawoffice)
-"soE" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/fairpoint/shipping/miningdock)
 "spp" = (
 /obj/structure/table/reinforced,
 /obj/structure/flora/pottedplant/large{
@@ -12759,7 +12640,7 @@
 "sxA" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "syZ" = (
 /obj/structure/sign/neon/big/gym,
 /turf/simulated/wall/concrete,
@@ -13348,7 +13229,6 @@
 /obj/structure/flora/pottedplant/large{
 	pixel_y = 15
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/crew_quarters/bar)
 "tlr" = (
@@ -13480,7 +13360,6 @@
 /area/fairpoint/street/west)
 "ttu" = (
 /obj/machinery/vending/lavatory,
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/cityhall)
 "ttC" = (
@@ -13866,7 +13745,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "uaU" = (
 /obj/effect/floor_decal/corner/grey/border{
 	tag = "icon-bordercolor (WEST)";
@@ -14483,7 +14362,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -14492,6 +14370,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "uXg" = (
@@ -14641,10 +14520,8 @@
 /turf/exterior/concrete/pavement/corner_invert,
 /area/fairpoint/street/east)
 "vhH" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood/ebony,
 /area/fairpoint/street/north)
 "vhP" = (
 /obj/structure/window/reinforced,
@@ -15016,7 +14893,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "vIY" = (
 /obj/structure/table/reinforced,
 /turf/simulated/floor/wood/maple,
@@ -15636,7 +15513,6 @@
 	name = "ATM";
 	pixel_x = 32
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/crew_quarters/bar)
 "wDJ" = (
@@ -15750,7 +15626,7 @@
 "wLw" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "wLK" = (
 /obj/effect/floor_decal/corner/red/full{
 	dir = 1
@@ -16010,9 +15886,11 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/chapel/office)
 "xfg" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/fairpoint/crew_quarters/bar)
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
+	},
+/turf/exterior/concrete/pavement/pave_tiling,
+/area/turbolift/sewer_entrance/mining)
 "xfY" = (
 /turf/exterior/concrete/pavement/empty,
 /area/fairpoint/street/north)
@@ -22170,7 +22048,7 @@ cUn
 mtP
 mtP
 hPr
-rLp
+dfi
 rHw
 rHw
 dfi
@@ -26535,8 +26413,8 @@ ncM
 cea
 gBh
 qCZ
-daM
-daM
+tFo
+tFo
 jyG
 hQp
 oYZ
@@ -26694,14 +26572,14 @@ eFa
 apf
 eFa
 qCZ
-daM
-daM
-daM
 tFo
 tFo
-daM
-daM
-daM
+tFo
+tFo
+tFo
+tFo
+tFo
+tFo
 iLR
 pVg
 pmO
@@ -27019,7 +26897,7 @@ tFo
 tFo
 tFo
 tFo
-daM
+tFo
 oTp
 pbc
 iLR
@@ -27171,14 +27049,14 @@ eFa
 eFa
 rNd
 tCh
-daM
-daM
-daM
-daM
-daM
-daM
 tFo
-daM
+tFo
+tFo
+tFo
+tFo
+tFo
+tFo
+tFo
 iLR
 pmO
 pmO
@@ -31491,7 +31369,7 @@ kVn
 kVn
 dzs
 iPz
-eYY
+gZX
 lYi
 akg
 qqO
@@ -31604,7 +31482,7 @@ rZp
 rPk
 rML
 sLB
-atn
+xfY
 atn
 atn
 xfY
@@ -31650,7 +31528,7 @@ kVn
 kVn
 dzs
 iPz
-eYY
+gZX
 mcl
 tpl
 pbf
@@ -31763,7 +31641,7 @@ bdN
 rPk
 rML
 sLB
-atn
+xfY
 atn
 atn
 xfY
@@ -32445,7 +32323,7 @@ kVn
 kVn
 dzs
 iPz
-fRO
+dUG
 jOi
 jOi
 jOi
@@ -32604,7 +32482,7 @@ kVn
 kVn
 dzs
 iPz
-fRO
+dUG
 beg
 oJT
 oJT
@@ -32763,7 +32641,7 @@ kVn
 kVn
 dzs
 iPz
-anZ
+cvU
 jOi
 fLk
 fLk
@@ -32922,7 +32800,7 @@ kVn
 kVn
 dzs
 iPz
-anZ
+cvU
 wFC
 igy
 igy
@@ -33671,7 +33549,7 @@ duH
 sts
 rML
 sLB
-atn
+xfY
 atn
 atn
 xfY
@@ -33830,7 +33708,7 @@ sts
 sts
 rML
 oKQ
-atn
+xfY
 atn
 atn
 xfY
@@ -33988,7 +33866,7 @@ rML
 rML
 rML
 rML
-xfY
+sLB
 xfY
 atn
 atn
@@ -36423,12 +36301,12 @@ odu
 lhN
 rAl
 rTn
-xfg
-xfg
-xfg
+lKV
+lKV
+lKV
 tlj
-xfg
-xfg
+lKV
+lKV
 fBu
 auQ
 toG
@@ -36746,7 +36624,7 @@ xvY
 lKV
 xvY
 xvY
-xfg
+lKV
 fBu
 cih
 cih
@@ -36900,12 +36778,12 @@ odu
 lhN
 rAl
 fQo
-xfg
-xfg
+lKV
+lKV
 wDE
 tlj
 xvY
-xfg
+lKV
 fBu
 fBu
 fBu
@@ -37062,12 +36940,12 @@ fQo
 fQo
 fQo
 fQo
-xfg
+lKV
 xvY
-xfg
-xfg
-xfg
-xfg
+lKV
+lKV
+lKV
+lKV
 fQo
 qXs
 qXs
@@ -37084,12 +36962,12 @@ nHY
 rfb
 wCx
 vQL
+sdt
+sdt
+sdt
 dSC
-dSC
-dSC
-dSC
-kYj
 eym
+sdt
 bxN
 vQL
 sdt
@@ -37243,12 +37121,12 @@ nHY
 rfb
 wCx
 vQL
-dSC
-dSC
-dSC
-dSC
-dSC
+sdt
+sdt
+sdt
+sdt
 eym
+sdt
 pFe
 gWz
 sdt
@@ -37383,9 +37261,9 @@ oBQ
 oBQ
 oBQ
 fQo
-xfg
-xfg
-xfg
+lKV
+lKV
+lKV
 fQo
 qXs
 lKV
@@ -37402,12 +37280,12 @@ nHY
 rfb
 wCx
 vQL
-dSC
-dSC
-dSC
-dSC
-dSC
+sdt
+sdt
+sdt
+sdt
 eym
+sdt
 dzF
 vQL
 sdt
@@ -37561,12 +37439,12 @@ nHY
 rfb
 wCx
 vQL
-dSC
-dSC
-dSC
-dSC
-dSC
+sdt
+sdt
+sdt
+sdt
 eym
+sdt
 sdt
 vQL
 vQL
@@ -37720,12 +37598,12 @@ nHY
 rfb
 wCx
 vQL
-dSC
-dSC
-dSC
-dSC
-dSC
+vQL
+sdt
+sdt
+vQL
 eym
+sdt
 beZ
 vQL
 sdt
@@ -37878,12 +37756,12 @@ wCx
 nHY
 rfb
 wCx
-gcI
+vQL
 ipl
 siI
 siI
-siI
 ipl
+sdt
 sdt
 qCD
 gWz
@@ -40204,7 +40082,7 @@ ovd
 dWz
 qJL
 ukF
-gsM
+vnr
 dpe
 aeu
 aeu
@@ -43135,7 +43013,7 @@ nHY
 nHY
 mvF
 mvF
-soE
+mHJ
 mHJ
 mvF
 mvF
@@ -43621,13 +43499,13 @@ pGF
 pGF
 mHJ
 wCx
-dWz
-dWz
-dWz
-dWz
-dWz
-dWz
-dWz
+daM
+daM
+daM
+daM
+daM
+daM
+daM
 nHY
 nHY
 wCx
@@ -43780,13 +43658,13 @@ lwb
 eAv
 mvF
 wCx
-dWz
+daM
 pkH
 pkH
 pkH
 pkH
 pkH
-dWz
+daM
 mav
 nHY
 wCx
@@ -43939,13 +43817,13 @@ aIV
 aIV
 mvF
 wCx
-dWz
+daM
 pkH
 pkH
 pkH
 pkH
 pkH
-mav
+xfg
 mav
 nHY
 wCx
@@ -44072,12 +43950,12 @@ eLz
 lfq
 dWz
 wCx
-dWz
-dWz
+cDc
+cDc
 sxA
 lDO
-vMm
-vMm
+qCl
+qCl
 sxA
 sxA
 cDc
@@ -44098,13 +43976,13 @@ ubu
 ubu
 mHJ
 wCx
-dWz
+daM
 pkH
 pkH
 pkH
 pkH
 pkH
-mav
+xfg
 mav
 nHY
 wCx
@@ -44231,12 +44109,12 @@ gNp
 gNp
 dWz
 wCx
-dWz
-dWz
+cDc
+cDc
 pZf
 vIV
-vMm
-vMm
+qCl
+qCl
 cXH
 cXZ
 cDc
@@ -44257,13 +44135,13 @@ aIV
 aIV
 mHJ
 wCx
-dWz
+daM
 pkH
 pkH
 pkH
 pkH
 pkH
-mav
+xfg
 mav
 nHY
 wCx
@@ -44390,8 +44268,8 @@ ajT
 ajT
 aUb
 wxK
-aUb
-aUb
+kth
+kth
 wLw
 wLw
 wLw
@@ -44416,13 +44294,13 @@ rVD
 rVD
 mvF
 wCx
-dWz
+daM
 pkH
 pkH
 pkH
 pkH
 pkH
-dWz
+daM
 mav
 nHY
 wCx
@@ -44549,8 +44427,8 @@ gNp
 gNp
 dWz
 wCx
-dWz
-dWz
+cDc
+cDc
 jhk
 uaa
 kPu
@@ -44575,13 +44453,13 @@ aIV
 mVe
 mvF
 wCx
-dWz
-dWz
-dWz
-dWz
-dWz
-dWz
-dWz
+daM
+daM
+daM
+daM
+daM
+daM
+daM
 nHY
 nHY
 wCx
@@ -44708,7 +44586,7 @@ gNp
 gNp
 dWz
 dHV
-dWz
+cDc
 ica
 pIJ
 rYd
@@ -44867,8 +44745,8 @@ gNp
 gNp
 dWz
 wCx
-dWz
-dWz
+cDc
+cDc
 bar
 rYd
 cdh
@@ -45199,7 +45077,7 @@ sXi
 sXi
 qkb
 qkb
-qCl
+rvv
 qkb
 qkb
 mop
@@ -46074,8 +45952,8 @@ rom
 rom
 rom
 rom
-btj
-btj
+nYR
+nYR
 pFA
 bbD
 nDw
@@ -46223,7 +46101,7 @@ maa
 maa
 maa
 xwW
-lSe
+nYR
 nYR
 rom
 rom
@@ -46381,8 +46259,8 @@ pFA
 maa
 maa
 maa
-maa
-mOf
+vhH
+nYR
 cIk
 jNh
 jNh
@@ -46540,8 +46418,8 @@ pFA
 uox
 maa
 maa
-maa
-hzc
+vhH
+nYR
 wtB
 dkX
 dkX
@@ -46700,7 +46578,7 @@ maa
 maa
 maa
 xwW
-vhH
+nYR
 nYR
 rom
 rom

--- a/maps/fairpoint/fairpoint-3.dmm
+++ b/maps/fairpoint/fairpoint-3.dmm
@@ -658,8 +658,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/cop)
 "fO" = (
-/obj/machinery/door/blast/shutters/open,
 /obj/effect/wingrille_spawn/reinforced,
+/obj/machinery/door/blast/shutters/open,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/cop)
 "fQ" = (
@@ -802,12 +802,10 @@
 /area/fairpoint/police/warden)
 "gN" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_top)
+/area/fairpoint/medical/medbay)
 "gP" = (
 /turf/simulated/floor/tiled/monotile,
 /area/fairpoint/street)
@@ -944,6 +942,12 @@
 /area/fairpoint/medical/cmo)
 "ia" = (
 /obj/structure/bookcase/manuals/medical,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "ie" = (
@@ -1282,9 +1286,6 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/turbolift/pd_top)
 "kN" = (
@@ -1431,6 +1432,9 @@
 "lH" = (
 /obj/structure/bookcase{
 	name = "bookcase (Fiction)"
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
@@ -2282,6 +2286,9 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/tactical)
+"sg" = (
+/turf/simulated/wall/elevator,
+/area/fairpoint/police)
 "sh" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -2301,16 +2308,8 @@
 /turf/simulated/floor,
 /area/fairpoint/medical/medbay)
 "sr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/machinery/door/airlock/glass/engineering,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/fairpoint/turret_protected/ai_server_room)
 "st" = (
@@ -2325,6 +2324,11 @@
 /obj/machinery/network/relay/long_range,
 /turf/simulated/floor/bluegrid,
 /area/fairpoint/maintenance/telecomms)
+"sL" = (
+/obj/effect/floor_decal/corner/paleblue,
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "sM" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -2676,6 +2680,9 @@
 /area/fairpoint/police)
 "vW" = (
 /obj/structure/coatrack,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "vX" = (
@@ -2961,11 +2968,10 @@
 /turf/simulated/floor/tiled/monofloor,
 /area/fairpoint/engineering/ce)
 "xP" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/structure/sign/warning/fall,
+/turf/simulated/wall/prepainted{
+	color = "FFFEFD"
 	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "xS" = (
 /obj/structure/table/woodentable/walnut,
@@ -3075,6 +3081,12 @@
 	},
 /turf/simulated/floor/carpet/blue,
 /area/fairpoint/police/detectives_office)
+"zk" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "zm" = (
 /turf/simulated/wall/concrete,
 /area/fairpoint/police/detectives_office)
@@ -3543,7 +3555,7 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/psych)
 "CM" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/pd_top)
 "CQ" = (
 /turf/simulated/floor/tiled/steel_ridged,
@@ -3582,6 +3594,13 @@
 /obj/structure/noticeboard,
 /turf/simulated/wall/r_wall,
 /area/fairpoint/police/cop)
+"Dz" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "DC" = (
 /obj/structure/table/reinforced,
 /obj/machinery/photocopier/faxmachine,
@@ -3659,10 +3678,25 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/exam_room)
+"Ee" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "Ef" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/maintenance/telecomms)
+"Er" = (
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "Es" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -4127,9 +4161,6 @@
 "HG" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
 /turf/simulated/floor,
 /area/fairpoint/turret_protected/ai_server_room)
 "HN" = (
@@ -4450,7 +4481,6 @@
 /turf/simulated/floor/lino,
 /area/fairpoint/police/detectives_office)
 "JY" = (
-/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/turbolift/hospital_top)
 "Ka" = (
@@ -4917,15 +4947,8 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/vacantoffice)
 "Oo" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_top)
+/turf/simulated/wall/elevator,
+/area/fairpoint/police/cop)
 "Or" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -5026,7 +5049,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/engineering/sysadmin)
 "Pw" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/hospital_top)
 "Py" = (
 /turf/simulated/floor/tiled/white,
@@ -5077,9 +5100,6 @@
 "PK" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
-	},
-/obj/structure/railing/mapped{
-	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turbolift/pd_top)
@@ -5163,16 +5183,18 @@
 /turf/simulated/floor/carpet/blue2,
 /area/fairpoint/police/cop)
 "QJ" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/fairpoint/medical/exam_room)
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "QL" = (
 /turf/simulated/wall/prepainted{
 	color = "FFFEFD"
 	},
 /area/fairpoint/medical/patient_wing)
+"QN" = (
+/obj/effect/floor_decal/corner/paleblue,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "QO" = (
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 4
@@ -5260,6 +5282,13 @@
 "Rv" = (
 /turf/simulated/wall/r_wall,
 /area/fairpoint/police/prison/dorm)
+"Rx" = (
+/obj/effect/floor_decal/corner/paleblue{
+	tag = "icon-corner_white (NORTH)";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "RA" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -5381,9 +5410,6 @@
 "SK" = (
 /obj/machinery/power/terminal{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
@@ -5532,11 +5558,8 @@
 /turf/simulated/floor/carpet/blue2,
 /area/fairpoint/medical/medbay)
 "TQ" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/fairpoint/turret_protected/ai_server_room)
+/turf/simulated/floor/tiled/dark,
+/area/turbolift/pd_top)
 "TR" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -5691,9 +5714,6 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/vacantoffice)
 "Uq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/light_switch/on{
 	dir = 1;
 	pixel_y = -18
@@ -6058,11 +6078,14 @@
 /turf/simulated/floor/reinforced,
 /area/fairpoint/panicroom)
 "XL" = (
-/obj/effect/floor_decal/corner/paleblue,
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_top)
+/area/fairpoint/medical/medbay)
 "XO" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/gloves/latex,
@@ -6327,12 +6350,13 @@
 /area/fairpoint/police/vacantoffice)
 "ZZ" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 5
 	},
-/obj/structure/railing/mapped,
-/obj/structure/lift/button/standalone,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_top)
+/area/fairpoint/medical/medbay)
 
 (1,1,1) = {"
 gi
@@ -16573,7 +16597,7 @@ Iv
 jz
 Xb
 SJ
-TQ
+SJ
 sr
 kK
 kK
@@ -18591,14 +18615,14 @@ cy
 cy
 cy
 cy
-cy
+Oo
 Ud
 Ud
 Ud
 Ud
 Ud
 oj
-Oo
+PK
 yH
 Zl
 hl
@@ -18750,13 +18774,13 @@ cy
 cy
 cy
 cy
-cy
+Oo
+CM
+CM
+CM
+CM
+CM
 Ud
-CM
-CM
-CM
-CM
-CM
 kL
 yH
 Zl
@@ -18909,13 +18933,13 @@ cy
 cy
 cy
 cy
-cy
-Ud
+Oo
 CM
 CM
 CM
 CM
 CM
+TQ
 aG
 yH
 Zl
@@ -19068,13 +19092,13 @@ cy
 cy
 cy
 cy
-cy
-Ud
+Oo
 CM
 CM
 CM
 CM
 CM
+TQ
 aG
 yH
 hz
@@ -19227,13 +19251,13 @@ cy
 cy
 cy
 cy
-cy
-Ud
+Oo
 CM
 CM
 CM
 CM
 CM
+TQ
 aG
 yH
 fL
@@ -19342,7 +19366,7 @@ MH
 MH
 MH
 yj
-ny
+qA
 ny
 ny
 ny
@@ -19386,13 +19410,13 @@ cy
 cy
 cy
 cy
-cy
+Oo
+CM
+CM
+CM
+CM
+CM
 Ud
-CM
-CM
-CM
-CM
-CM
 kL
 yH
 Zl
@@ -19501,7 +19525,7 @@ wQ
 xV
 xV
 sA
-ny
+Rx
 ny
 ny
 ny
@@ -19545,7 +19569,7 @@ JT
 JT
 JT
 JT
-JT
+sg
 Ud
 Ji
 Ud
@@ -19660,7 +19684,7 @@ wQ
 xV
 xV
 xV
-ny
+Ee
 ny
 ny
 zK
@@ -19819,7 +19843,7 @@ VS
 VS
 VS
 gA
-ny
+qA
 ny
 ny
 uh
@@ -19978,7 +20002,7 @@ gj
 RP
 RP
 gA
-ny
+qA
 ny
 ny
 BS
@@ -20137,7 +20161,7 @@ mN
 yj
 yj
 yj
-ny
+qA
 ny
 ny
 ny
@@ -20293,15 +20317,15 @@ DX
 mN
 mN
 mN
+ZZ
+UX
+UX
+gN
 ny
 ny
 ny
 ny
-ny
-ny
-ny
-ny
-ny
+mA
 mM
 ny
 ny
@@ -20452,11 +20476,11 @@ pe
 Ir
 ok
 mN
+qA
 ny
 ny
 ny
-ny
-ny
+QN
 vW
 vW
 lH
@@ -20611,11 +20635,11 @@ gq
 an
 Cc
 mN
+qA
 ny
 ny
 ny
-ny
-ny
+mA
 QL
 QL
 QL
@@ -20770,11 +20794,11 @@ gq
 an
 Cc
 mN
+qA
 ny
 ny
 ny
-ny
-ny
+mA
 QL
 Iu
 Iu
@@ -20929,11 +20953,11 @@ dn
 Lv
 KW
 mN
+qA
 ny
 ny
 ny
-ny
-ny
+mA
 QL
 Iu
 Iu
@@ -21088,11 +21112,11 @@ UC
 bi
 bi
 mN
+qA
 ny
 ny
 ny
-ny
-ny
+mA
 QL
 Iu
 Iu
@@ -21243,11 +21267,11 @@ mN
 Wr
 mN
 mN
-qA
 ny
-ny
-ny
-ny
+zk
+UX
+UX
+gN
 ny
 ny
 ny
@@ -21402,15 +21426,15 @@ iD
 EE
 um
 mN
-qA
+Ee
 ny
 ny
 ny
-ny
-ny
-ny
-ny
-ny
+QN
+vg
+vg
+vg
+XL
 QL
 Iu
 Iu
@@ -21565,7 +21589,7 @@ qA
 ny
 ny
 ny
-ny
+mA
 qi
 qi
 qi
@@ -21724,7 +21748,7 @@ qA
 ny
 ny
 ny
-ny
+mA
 qi
 qL
 gd
@@ -21883,7 +21907,7 @@ qA
 ny
 ny
 ny
-ny
+mA
 qi
 qL
 EU
@@ -22040,9 +22064,9 @@ qQ
 qQ
 qA
 ny
-ny
-ny
-ny
+QN
+vg
+XL
 qi
 gJ
 KL
@@ -22199,9 +22223,9 @@ uJ
 qQ
 ji
 ny
-ny
-ZZ
+mA
 hT
+Vy
 Vy
 Vy
 Vy
@@ -22358,8 +22382,8 @@ pm
 SP
 ny
 ny
-ny
-gN
+Dz
+Vy
 Pw
 Pw
 Pw
@@ -22517,7 +22541,7 @@ So
 qQ
 fd
 ny
-ny
+QJ
 JY
 Pw
 Pw
@@ -22676,7 +22700,7 @@ So
 SF
 qA
 ny
-ny
+QJ
 JY
 Pw
 Pw
@@ -22835,7 +22859,7 @@ So
 SF
 qA
 ny
-ny
+QJ
 JY
 Pw
 Pw
@@ -22994,8 +23018,8 @@ So
 qQ
 gH
 ny
-ny
-XL
+sL
+Vy
 Pw
 Pw
 Pw
@@ -23153,9 +23177,9 @@ aX
 qQ
 qA
 ny
-ny
+mA
 xP
-QJ
+Tg
 Tg
 Tg
 Tg
@@ -23312,8 +23336,8 @@ qQ
 Mj
 ES
 ny
-ny
-mA
+zk
+Er
 Tg
 ey
 Zr

--- a/maps/fairpoint/fairpoint-3.dmm
+++ b/maps/fairpoint/fairpoint-3.dmm
@@ -499,7 +499,8 @@
 /area/fairpoint/police/prison)
 "eC" = (
 /obj/structure/ladder,
-/turf/simulated/floor/tiled,
+/obj/structure/lattice,
+/turf/simulated/open,
 /area/fairpoint/cityhall)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
@@ -741,7 +742,7 @@
 /area/fairpoint/medical/biostorage)
 "gy" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/prison)
 "gA" = (
 /obj/machinery/recharger/wallcharger,
@@ -1190,7 +1191,7 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard West"
 	},
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/prison)
 "jX" = (
 /obj/effect/wingrille_spawn/reinforced,
@@ -1433,7 +1434,7 @@
 /obj/item/rig/ce/equipped,
 /obj/item/clothing/mask/gas/half,
 /obj/item/tank/oxygen/yellow,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "lX" = (
 /obj/structure/bed/sofa,
@@ -2043,7 +2044,7 @@
 "qT" = (
 /obj/structure/window/borosilicate_reinforced,
 /obj/structure/sealant_injector,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "qU" = (
 /obj/machinery/camera/network/security{
@@ -2346,8 +2347,11 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
+"tG" = (
+/turf/simulated/open,
+/area/fairpoint/crew_quarters/bar)
 "tL" = (
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/street)
@@ -2424,7 +2428,7 @@
 /area/fairpoint/medical/patient_b)
 "uA" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/armoury)
 "uB" = (
 /obj/effect/floor_decal/corner/red{
@@ -2568,7 +2572,7 @@
 /area/fairpoint/police/vacantoffice)
 "vN" = (
 /obj/structure/window/borosilicate_reinforced,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "vP" = (
 /turf/simulated/floor/tiled/dark,
@@ -2607,7 +2611,7 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "vX" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/armoury)
 "wa" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -2640,7 +2644,7 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard West"
 	},
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/cop)
 "wl" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -2881,7 +2885,7 @@
 /area/fairpoint/police/brig/interrogation)
 "xM" = (
 /obj/machinery/door/window/southleft,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "xP" = (
 /obj/structure/sign/warning/fall,
@@ -3190,7 +3194,7 @@
 /area/fairpoint/maintenance/telecomms)
 "AV" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/cop)
 "AW" = (
 /obj/effect/floor_decal/corner/grey{
@@ -3231,7 +3235,7 @@
 /turf/simulated/floor/carpet/blue2,
 /area/fairpoint/police/cop)
 "Bi" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/prison)
 "Bj" = (
 /obj/structure/table/reinforced,
@@ -3403,7 +3407,7 @@
 /turf/simulated/floor/wood/ebony,
 /area/fairpoint/police/cop)
 "Cp" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "Cq" = (
 /obj/machinery/door/blast/shutters{
@@ -3492,6 +3496,13 @@
 "Dh" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/patient_c)
+"Dm" = (
+/obj/abstract/map_data{
+	height = 3
+	},
+/obj/abstract/level_data/main_level,
+/turf/simulated/wall/concrete,
+/area/fairpoint/street/outskirts)
 "Dn" = (
 /obj/structure/sign/warning/secure_area,
 /turf/simulated/wall/r_wall,
@@ -4014,7 +4025,7 @@
 /area/fairpoint/police/cop)
 "Hl" = (
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "Hm" = (
 /obj/effect/floor_decal/corner/paleblue/full{
@@ -4035,7 +4046,7 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/cmo)
 "Hp" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/cop)
 "Hs" = (
 /obj/structure/window/reinforced{
@@ -5208,7 +5219,7 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/detectives_office)
 "RT" = (
-/turf/exterior/open,
+/turf/simulated/open,
 /area/fairpoint/medical/medbay)
 "RW" = (
 /obj/structure/bed/chair/armchair/lime{
@@ -5773,7 +5784,7 @@
 /obj/structure/sealant_rack,
 /obj/item/gun/launcher/sealant,
 /obj/machinery/camera/network/engineering,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "Wr" = (
 /obj/structure/door/walnut{
@@ -6362,7 +6373,7 @@ gi
 gi
 gi
 yC
-yC
+Dm
 "}
 (2,1,1) = {"
 mS
@@ -26341,13 +26352,13 @@ nB
 nB
 nB
 Yg
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 Yg
 Yg
@@ -26500,15 +26511,15 @@ nB
 nB
 nB
 Yg
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -26659,15 +26670,15 @@ nB
 nB
 nB
 Yg
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -26818,15 +26829,15 @@ nB
 nB
 nB
 Yg
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -26977,15 +26988,15 @@ Yg
 Yg
 Yg
 Yg
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -27136,15 +27147,15 @@ wS
 wS
 wS
 BI
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -27295,15 +27306,15 @@ wS
 wS
 wS
 BI
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -27454,15 +27465,15 @@ wS
 wS
 wS
 BI
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -27613,15 +27624,15 @@ wS
 wS
 wS
 BI
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -27772,15 +27783,15 @@ wS
 wS
 wS
 BI
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB
@@ -27931,15 +27942,15 @@ Qr
 Qr
 Qr
 BI
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
-SN
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
+tG
 Yg
 UB
 UB

--- a/maps/fairpoint/fairpoint-3.dmm
+++ b/maps/fairpoint/fairpoint-3.dmm
@@ -75,10 +75,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/turbolift/pd_top)
-"aS" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/open,
-/area/fairpoint/street)
 "aX" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/structure/filingcabinet/filingcabinet,
@@ -129,11 +125,6 @@
 /obj/structure/window/reinforced/polarized/full,
 /turf/simulated/floor/wood,
 /area/fairpoint/medical/psych)
-"bv" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/wall,
-/area/fairpoint/street)
 "by" = (
 /turf/simulated/wall/r_wall,
 /area/fairpoint/turret_protected/ai_server_room)
@@ -335,7 +326,6 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
-/obj/effect/wingrille_spawn/reinforced_borosilicate,
 /turf/simulated/floor,
 /area/fairpoint/turret_protected/ai_server_room)
 "di" = (
@@ -345,10 +335,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/patient_wing)
-"dj" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/street)
 "dn" = (
 /obj/effect/floor_decal/carpet/blue2,
 /obj/effect/floor_decal/carpet/blue2{
@@ -822,7 +808,6 @@
 /turf/simulated/floor/greengrid,
 /area/fairpoint/turret_protected/ai_server_room)
 "gX" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/glass/security,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/prison/dorm)
@@ -1349,11 +1334,6 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/prison)
 "lm" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/police/warden)
@@ -1546,15 +1526,6 @@
 /obj/machinery/telecomms/server/presets/science,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/maintenance/telecomms)
-"mz" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/fairpoint/police/brig/interrogation)
 "mA" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -1641,14 +1612,6 @@
 /obj/item/taperecorder,
 /turf/simulated/floor/carpet/blue2,
 /area/fairpoint/police/cop)
-"nn" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/fairpoint/police/prison)
 "np" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/grey{
@@ -1800,10 +1763,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/vacantoffice)
-"ox" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/walnut,
-/area/fairpoint/street/outskirts)
 "oy" = (
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /obj/machinery/hologram/holopad,
@@ -1953,13 +1912,6 @@
 /obj/machinery/smartfridge/secure/medbay,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/biostorage)
-"qb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/turf/simulated/floor/reinforced,
-/area/fairpoint/police/cop)
 "qe" = (
 /obj/structure/table/reinforced,
 /obj/item/taperecorder,
@@ -2097,11 +2049,6 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard East";
 	dir = 9
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/box/gloves,
@@ -2257,11 +2204,6 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/detectives_office)
 "rX" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006
@@ -2350,17 +2292,8 @@
 /obj/item/clothing/mask/muzzle,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/prison)
-"tl" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/fairpoint/police/cop)
 "tq" = (
 /obj/effect/wallframe_spawn/reinforced,
-/obj/effect/wingrille_spawn/reinforced_borosilicate,
 /turf/simulated/floor,
 /area/fairpoint/turret_protected/ai_server_room)
 "tr" = (
@@ -2489,13 +2422,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/patient_b)
-"uu" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood/ebony,
-/area/fairpoint/police/cop)
 "uA" = (
 /obj/machinery/porta_turret,
 /turf/simulated/floor/tiled/monofloor,
@@ -2620,11 +2546,6 @@
 /area/fairpoint/police)
 "vy" = (
 /obj/structure/table/reinforced,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/detectives_office)
 "vA" = (
@@ -2848,11 +2769,6 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/cmo)
 "xb" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -3188,12 +3104,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/turret_protected/ai_server_room)
-"zY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/padded,
-/obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled/dark,
-/area/fairpoint/police/prison/dorm)
 "zZ" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -3725,10 +3635,6 @@
 /obj/item/storage/firstaid,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/biostorage)
-"Ez" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/police/cop)
 "EA" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -3737,14 +3643,6 @@
 /obj/structure/hygiene/shower,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/vacantoffice)
-"EC" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/fairpoint/police/armoury)
 "ED" = (
 /obj/machinery/network/mainframe/software,
 /turf/simulated/floor/blackgrid,
@@ -3834,11 +3732,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/fairpoint/police/main)
 "Fo" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/accessory/armor/helmcover/blue,
 /obj/item/clothing/accessory/armor/helmcover/blue,
@@ -4226,11 +4119,6 @@
 	c_tag = "SEC - Brig Starboard";
 	dir = 9
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police)
 "Ii" = (
@@ -4352,14 +4240,6 @@
 /obj/item/storage/box/armband/med,
 /turf/simulated/floor/tiled,
 /area/fairpoint/medical/biostorage)
-"Ji" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/wall/elevator,
-/area/turbolift/pd_top)
 "Jj" = (
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 4
@@ -4714,18 +4594,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/prison/dorm)
 "Mo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/street)
+/turf/unsimulated/mask,
+/area/fairpoint/street/outskirts)
 "Mr" = (
 /obj/structure/bed/chair/office/light{
 	tag = "icon-officechair_white (WEST)";
@@ -4938,11 +4811,6 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/simulated/floor/lino,
 /area/fairpoint/police/detectives_office)
-"NZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/open,
-/area/fairpoint/street)
 "Om" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/vacantoffice)
@@ -4958,10 +4826,6 @@
 /obj/item/sticky_pad/random,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/police/warden)
-"OF" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/wall,
-/area/fairpoint/street)
 "OG" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -5371,9 +5235,6 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/cmo)
-"Sq" = (
-/turf/space,
-/area/fairpoint/street/outskirts)
 "Sv" = (
 /obj/structure/extinguisher_cabinet,
 /turf/simulated/wall/concrete,
@@ -5428,14 +5289,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/cmo)
-"SQ" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/fairpoint/police/detectives_office)
 "SR" = (
 /obj/structure/bed/sofa{
 	dir = 10
@@ -5965,12 +5818,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/turret_protected/ai_server_room)
-"WG" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/street)
 "WH" = (
 /obj/structure/bed/sofa{
 	dir = 4
@@ -6515,7 +6362,7 @@ gi
 gi
 gi
 yC
-Sq
+yC
 "}
 (2,1,1) = {"
 mS
@@ -6674,7 +6521,7 @@ gi
 gi
 gi
 yC
-Sq
+yC
 "}
 (3,1,1) = {"
 mS
@@ -6833,7 +6680,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (4,1,1) = {"
 mS
@@ -6992,7 +6839,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (5,1,1) = {"
 mS
@@ -7151,7 +6998,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (6,1,1) = {"
 mS
@@ -7310,7 +7157,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (7,1,1) = {"
 mS
@@ -7469,7 +7316,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (8,1,1) = {"
 mS
@@ -7628,7 +7475,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (9,1,1) = {"
 mS
@@ -7787,7 +7634,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (10,1,1) = {"
 mS
@@ -7946,7 +7793,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (11,1,1) = {"
 mS
@@ -8105,7 +7952,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (12,1,1) = {"
 mS
@@ -8264,7 +8111,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (13,1,1) = {"
 mS
@@ -8423,7 +8270,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (14,1,1) = {"
 mS
@@ -8582,7 +8429,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (15,1,1) = {"
 mS
@@ -8741,7 +8588,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (16,1,1) = {"
 mS
@@ -8900,7 +8747,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (17,1,1) = {"
 mS
@@ -9059,7 +8906,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (18,1,1) = {"
 mS
@@ -9218,7 +9065,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (19,1,1) = {"
 mS
@@ -9377,7 +9224,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (20,1,1) = {"
 mS
@@ -9536,7 +9383,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (21,1,1) = {"
 mS
@@ -9695,7 +9542,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (22,1,1) = {"
 mS
@@ -9854,7 +9701,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (23,1,1) = {"
 mS
@@ -10013,7 +9860,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (24,1,1) = {"
 mS
@@ -10172,7 +10019,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (25,1,1) = {"
 mS
@@ -10331,7 +10178,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (26,1,1) = {"
 mS
@@ -10490,7 +10337,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (27,1,1) = {"
 mS
@@ -10649,7 +10496,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (28,1,1) = {"
 mS
@@ -10808,7 +10655,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (29,1,1) = {"
 mS
@@ -10967,7 +10814,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (30,1,1) = {"
 mS
@@ -11126,7 +10973,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (31,1,1) = {"
 mS
@@ -11285,7 +11132,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (32,1,1) = {"
 mS
@@ -11444,7 +11291,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (33,1,1) = {"
 mS
@@ -11603,7 +11450,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (34,1,1) = {"
 mS
@@ -11762,7 +11609,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (35,1,1) = {"
 mS
@@ -11921,7 +11768,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (36,1,1) = {"
 mS
@@ -12080,7 +11927,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (37,1,1) = {"
 mS
@@ -12239,7 +12086,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (38,1,1) = {"
 mS
@@ -12398,7 +12245,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (39,1,1) = {"
 mS
@@ -12557,7 +12404,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (40,1,1) = {"
 mS
@@ -12716,7 +12563,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (41,1,1) = {"
 mS
@@ -12875,7 +12722,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (42,1,1) = {"
 mS
@@ -13034,7 +12881,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (43,1,1) = {"
 mS
@@ -13193,7 +13040,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (44,1,1) = {"
 mS
@@ -13352,7 +13199,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (45,1,1) = {"
 mS
@@ -13511,7 +13358,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (46,1,1) = {"
 mS
@@ -13670,7 +13517,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (47,1,1) = {"
 mS
@@ -13829,7 +13676,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (48,1,1) = {"
 mS
@@ -13988,7 +13835,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (49,1,1) = {"
 mS
@@ -14147,7 +13994,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (50,1,1) = {"
 mS
@@ -14306,7 +14153,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (51,1,1) = {"
 mS
@@ -14465,7 +14312,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (52,1,1) = {"
 mS
@@ -14624,7 +14471,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (53,1,1) = {"
 mS
@@ -14783,7 +14630,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (54,1,1) = {"
 mS
@@ -14942,7 +14789,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (55,1,1) = {"
 mS
@@ -15101,7 +14948,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (56,1,1) = {"
 mS
@@ -15260,7 +15107,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (57,1,1) = {"
 mS
@@ -15419,7 +15266,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (58,1,1) = {"
 mS
@@ -15430,7 +15277,7 @@ UB
 mT
 GV
 JO
-Ez
+tB
 GV
 mT
 HZ
@@ -15578,7 +15425,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (59,1,1) = {"
 mS
@@ -15587,9 +15434,9 @@ mS
 UB
 UB
 mT
-qb
+GV
 tB
-Ez
+tB
 GV
 mT
 ev
@@ -15737,7 +15584,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (60,1,1) = {"
 mS
@@ -15896,7 +15743,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (61,1,1) = {"
 mS
@@ -15906,7 +15753,7 @@ UB
 UB
 mT
 TZ
-Ez
+tB
 tB
 TZ
 mT
@@ -16055,7 +15902,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (62,1,1) = {"
 mS
@@ -16065,8 +15912,8 @@ UB
 UB
 mT
 TZ
-Ez
-Ez
+tB
+tB
 TZ
 mT
 LR
@@ -16214,7 +16061,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (63,1,1) = {"
 mS
@@ -16225,7 +16072,7 @@ UB
 mT
 TZ
 tB
-Ez
+tB
 TZ
 Jm
 Fe
@@ -16373,7 +16220,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (64,1,1) = {"
 mS
@@ -16382,7 +16229,7 @@ mS
 UB
 UB
 ce
-Ez
+tB
 tB
 tB
 tB
@@ -16532,7 +16379,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (65,1,1) = {"
 mS
@@ -16542,7 +16389,7 @@ UB
 UB
 mT
 tB
-tl
+tB
 tB
 tB
 Dn
@@ -16691,7 +16538,7 @@ mS
 mS
 mS
 yC
-Sq
+yC
 "}
 (66,1,1) = {"
 mS
@@ -16850,7 +16697,7 @@ UB
 UB
 UB
 yC
-Sq
+yC
 "}
 (67,1,1) = {"
 mS
@@ -17009,7 +16856,7 @@ UB
 UB
 mS
 yC
-Sq
+yC
 "}
 (68,1,1) = {"
 mS
@@ -17049,7 +16896,7 @@ Fy
 bg
 zm
 zm
-SQ
+yX
 yX
 yX
 yX
@@ -17345,7 +17192,7 @@ zs
 gm
 fX
 Hh
-uu
+Hh
 mT
 LK
 LK
@@ -18785,7 +18632,7 @@ kL
 yH
 Zl
 hl
-mz
+JL
 JL
 JL
 SD
@@ -19076,7 +18923,7 @@ UG
 UG
 Tj
 yC
-Sq
+yC
 "}
 (81,1,1) = {"
 mS
@@ -19235,7 +19082,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (82,1,1) = {"
 mS
@@ -19394,7 +19241,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (83,1,1) = {"
 mS
@@ -19553,7 +19400,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (84,1,1) = {"
 mS
@@ -19571,7 +19418,7 @@ JT
 JT
 sg
 Ud
-Ji
+Ud
 Ud
 Ud
 Ud
@@ -19712,7 +19559,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (85,1,1) = {"
 mS
@@ -19871,7 +19718,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (86,1,1) = {"
 mS
@@ -20030,7 +19877,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (87,1,1) = {"
 mS
@@ -20189,7 +20036,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (88,1,1) = {"
 mS
@@ -20348,7 +20195,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (89,1,1) = {"
 mS
@@ -20507,7 +20354,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (90,1,1) = {"
 mS
@@ -20666,7 +20513,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (91,1,1) = {"
 mS
@@ -20825,7 +20672,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (92,1,1) = {"
 mS
@@ -20984,7 +20831,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (93,1,1) = {"
 mS
@@ -21143,7 +20990,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (94,1,1) = {"
 mS
@@ -21302,7 +21149,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (95,1,1) = {"
 mS
@@ -21461,7 +21308,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (96,1,1) = {"
 mS
@@ -21620,7 +21467,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (97,1,1) = {"
 mS
@@ -21631,7 +21478,7 @@ mS
 lB
 wX
 CG
-nn
+uM
 uM
 uM
 uM
@@ -21779,7 +21626,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (98,1,1) = {"
 mS
@@ -21938,7 +21785,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (99,1,1) = {"
 mS
@@ -22097,7 +21944,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (100,1,1) = {"
 mS
@@ -22256,7 +22103,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (101,1,1) = {"
 mS
@@ -22268,7 +22115,7 @@ lB
 Bi
 Bi
 Rv
-zY
+An
 vP
 HQ
 Ui
@@ -22415,7 +22262,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (102,1,1) = {"
 mS
@@ -22574,7 +22421,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (103,1,1) = {"
 mS
@@ -22733,7 +22580,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (104,1,1) = {"
 mS
@@ -22767,7 +22614,7 @@ SG
 Nr
 Zo
 Xa
-EC
+vH
 GE
 jh
 vH
@@ -22892,7 +22739,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (105,1,1) = {"
 mS
@@ -23051,7 +22898,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (106,1,1) = {"
 mS
@@ -23210,7 +23057,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (107,1,1) = {"
 mS
@@ -23369,7 +23216,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (108,1,1) = {"
 mS
@@ -23528,7 +23375,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (109,1,1) = {"
 mS
@@ -23687,7 +23534,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (110,1,1) = {"
 mS
@@ -23846,7 +23693,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (111,1,1) = {"
 mS
@@ -24005,7 +23852,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (112,1,1) = {"
 mS
@@ -24164,7 +24011,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (113,1,1) = {"
 mS
@@ -24323,7 +24170,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (114,1,1) = {"
 mS
@@ -24482,7 +24329,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (115,1,1) = {"
 mS
@@ -24641,7 +24488,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (116,1,1) = {"
 mS
@@ -24800,7 +24647,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (117,1,1) = {"
 mS
@@ -24959,7 +24806,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (118,1,1) = {"
 mS
@@ -25118,7 +24965,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (119,1,1) = {"
 mS
@@ -25277,7 +25124,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (120,1,1) = {"
 mS
@@ -25436,7 +25283,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (121,1,1) = {"
 mS
@@ -25595,7 +25442,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (122,1,1) = {"
 mS
@@ -25754,7 +25601,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (123,1,1) = {"
 mS
@@ -25913,7 +25760,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (124,1,1) = {"
 VV
@@ -26072,7 +25919,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (125,1,1) = {"
 VV
@@ -26231,7 +26078,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (126,1,1) = {"
 VV
@@ -26390,7 +26237,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (127,1,1) = {"
 VV
@@ -26549,7 +26396,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (128,1,1) = {"
 VV
@@ -26668,11 +26515,11 @@ UB
 UB
 UG
 ET
-UG
-UG
-UG
-UG
-UG
+Mo
+Mo
+Mo
+Mo
+ET
 ET
 De
 De
@@ -26708,7 +26555,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (129,1,1) = {"
 VV
@@ -26827,11 +26674,11 @@ UB
 UB
 UG
 ET
-UG
-UG
-UG
-UG
-UG
+Mo
+Mo
+Mo
+Mo
+ET
 ET
 De
 De
@@ -26867,7 +26714,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (130,1,1) = {"
 VV
@@ -26883,10 +26730,10 @@ VV
 VV
 VV
 VV
-OF
 VV
-OF
-OF
+VV
+VV
+VV
 VV
 VV
 VV
@@ -26986,11 +26833,11 @@ UB
 UB
 UG
 ET
-UG
-UG
-UG
-UG
-UG
+Mo
+Mo
+Mo
+Mo
+ET
 ET
 De
 De
@@ -27026,7 +26873,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (131,1,1) = {"
 VV
@@ -27044,7 +26891,7 @@ VV
 VV
 VV
 VV
-OF
+VV
 VV
 VV
 VV
@@ -27145,11 +26992,11 @@ UB
 UB
 UG
 ET
-UG
-UG
-UG
-UG
-UG
+Mo
+Mo
+Mo
+Mo
+ET
 ET
 De
 De
@@ -27185,7 +27032,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (132,1,1) = {"
 VV
@@ -27203,8 +27050,8 @@ VV
 VV
 VV
 VV
-OF
-OF
+VV
+VV
 VV
 VV
 VV
@@ -27304,11 +27151,11 @@ UB
 UB
 UG
 ET
-UG
-UG
-UG
-UG
-UG
+ET
+De
+De
+ET
+ET
 ET
 De
 De
@@ -27344,7 +27191,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (133,1,1) = {"
 VV
@@ -27463,7 +27310,7 @@ UB
 UB
 UG
 ET
-ox
+nh
 nh
 nh
 nh
@@ -27503,7 +27350,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (134,1,1) = {"
 VV
@@ -27521,7 +27368,7 @@ VV
 VV
 VV
 VV
-OF
+VV
 VV
 VV
 VV
@@ -27662,7 +27509,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (135,1,1) = {"
 VV
@@ -27821,7 +27668,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (136,1,1) = {"
 VV
@@ -27980,7 +27827,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (137,1,1) = {"
 VV
@@ -28139,7 +27986,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (138,1,1) = {"
 VV
@@ -28298,7 +28145,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (139,1,1) = {"
 VV
@@ -28457,7 +28304,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (140,1,1) = {"
 VV
@@ -28616,7 +28463,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (141,1,1) = {"
 VV
@@ -28775,7 +28622,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (142,1,1) = {"
 VV
@@ -28934,7 +28781,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (143,1,1) = {"
 VV
@@ -29093,7 +28940,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (144,1,1) = {"
 VV
@@ -29252,7 +29099,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (145,1,1) = {"
 VV
@@ -29411,7 +29258,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (146,1,1) = {"
 VV
@@ -29570,7 +29417,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (147,1,1) = {"
 VV
@@ -29729,7 +29576,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (148,1,1) = {"
 VV
@@ -29888,7 +29735,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (149,1,1) = {"
 VV
@@ -30047,7 +29894,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (150,1,1) = {"
 VV
@@ -30206,7 +30053,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (151,1,1) = {"
 VV
@@ -30365,7 +30212,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (152,1,1) = {"
 VV
@@ -30524,7 +30371,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (153,1,1) = {"
 VV
@@ -30683,7 +30530,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (154,1,1) = {"
 VV
@@ -30842,7 +30689,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (155,1,1) = {"
 VV
@@ -31001,7 +30848,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (156,1,1) = {"
 VV
@@ -31160,7 +31007,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (157,1,1) = {"
 VV
@@ -31319,7 +31166,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (158,1,1) = {"
 VV
@@ -31478,7 +31325,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (159,1,1) = {"
 VV
@@ -31637,7 +31484,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (160,1,1) = {"
 VV
@@ -31796,7 +31643,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (161,1,1) = {"
 VV
@@ -31955,7 +31802,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (162,1,1) = {"
 VV
@@ -32114,7 +31961,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (163,1,1) = {"
 VV
@@ -32273,7 +32120,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (164,1,1) = {"
 VV
@@ -32281,9 +32128,9 @@ VV
 VV
 VV
 VV
-OF
 VV
-OF
+VV
+VV
 VV
 VV
 VV
@@ -32432,20 +32279,20 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (165,1,1) = {"
 VV
 VV
 VV
 VV
-OF
-OF
 VV
 VV
 VV
 VV
-OF
+VV
+VV
+VV
 VV
 VV
 VV
@@ -32591,7 +32438,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (166,1,1) = {"
 VV
@@ -32599,11 +32446,11 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
-OF
+VV
+VV
 VV
 VV
 VV
@@ -32750,7 +32597,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (167,1,1) = {"
 VV
@@ -32760,7 +32607,7 @@ VV
 VV
 VV
 VV
-OF
+VV
 VV
 VV
 VV
@@ -32909,19 +32756,19 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (168,1,1) = {"
 VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
 VV
-OF
+VV
+VV
 VV
 VV
 VV
@@ -33068,19 +32915,19 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (169,1,1) = {"
 VV
 VV
 VV
 VV
-OF
-OF
-OF
 VV
-OF
-OF
+VV
+VV
+VV
+VV
+VV
 VV
 VV
 VV
@@ -33227,7 +33074,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (170,1,1) = {"
 VV
@@ -33235,8 +33082,8 @@ VV
 VV
 VV
 VV
-OF
-OF
+VV
+VV
 VV
 VV
 VV
@@ -33386,7 +33233,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (171,1,1) = {"
 VV
@@ -33406,15 +33253,15 @@ VV
 VV
 VV
 VV
-OF
-VV
-OF
 VV
 VV
 VV
-dj
+VV
+VV
+VV
 mS
-dj
+mS
+mS
 mS
 UB
 UB
@@ -33545,7 +33392,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (172,1,1) = {"
 VV
@@ -33564,20 +33411,17 @@ VV
 VV
 VV
 VV
-OF
-OF
 VV
 VV
 VV
 VV
-OF
-dj
+VV
+VV
+VV
 mS
 mS
 mS
-UB
-aS
-aS
+mS
 UB
 UB
 UB
@@ -33586,9 +33430,12 @@ UB
 UB
 UB
 UB
-aS
-aS
-aS
+UB
+UB
+UB
+UB
+UB
+UB
 UB
 UB
 UB
@@ -33704,7 +33551,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (173,1,1) = {"
 VV
@@ -33712,7 +33559,6 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
@@ -33724,30 +33570,31 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
-OF
 VV
-dj
+VV
+VV
+VV
 mS
 mS
 mS
-aS
-UB
-aS
+mS
 UB
 UB
 UB
 UB
 UB
-aS
-aS
-aS
-aS
-aS
-aS
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
 UB
 UB
 UB
@@ -33863,20 +33710,20 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (174,1,1) = {"
 VV
 VV
 VV
 VV
-OF
-OF
 VV
 VV
 VV
 VV
-OF
+VV
+VV
+VV
 VV
 VV
 VV
@@ -33891,22 +33738,22 @@ VV
 VV
 mS
 mS
-dj
+mS
 mS
 UB
 UB
-aS
 UB
 UB
 UB
 UB
 UB
-aS
-aS
-aS
-aS
-aS
-aS
+UB
+UB
+UB
+UB
+UB
+UB
+UB
 UB
 UB
 UB
@@ -34022,7 +33869,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (175,1,1) = {"
 VV
@@ -34030,42 +33877,42 @@ VV
 VV
 VV
 VV
-OF
-VV
-VV
-VV
-OF
 VV
 VV
 VV
 VV
-OF
-OF
-OF
-OF
 VV
 VV
-OF
 VV
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 mS
 mS
 mS
 mS
-aS
-UB
-aS
 UB
 UB
 UB
 UB
 UB
-aS
-aS
-aS
-aS
-aS
-aS
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
 UB
 UB
 UB
@@ -34181,7 +34028,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (176,1,1) = {"
 VV
@@ -34191,40 +34038,40 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
 VV
 VV
-OF
-OF
-OF
-OF
-OF
 VV
-OF
-OF
 VV
-OF
-dj
-dj
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 mS
-dj
-aS
-UB
-aS
-UB
+mS
+mS
+mS
 UB
 UB
 UB
 UB
-aS
-aS
-aS
-aS
-aS
-aS
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
 UB
 UB
 UB
@@ -34340,19 +34187,13 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (177,1,1) = {"
 VV
 VV
 VV
 VV
-OF
-VV
-VV
-VV
-VV
-OF
 VV
 VV
 VV
@@ -34366,24 +34207,30 @@ VV
 VV
 VV
 VV
-dj
-dj
+VV
+VV
+VV
+VV
+VV
+VV
+mS
+mS
 mS
 mS
 UB
 UB
-aS
 UB
 UB
 UB
 UB
 UB
-aS
-aS
-aS
-aS
-aS
-aS
+UB
+UB
+UB
+UB
+UB
+UB
+UB
 UB
 UB
 UB
@@ -34499,19 +34346,19 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (178,1,1) = {"
 VV
 VV
 VV
 VV
-OF
-OF
-OF
 VV
-OF
-OF
+VV
+VV
+VV
+VV
+VV
 VV
 VV
 VV
@@ -34531,7 +34378,7 @@ mS
 mS
 UB
 UB
-aS
+UB
 UB
 UB
 UB
@@ -34658,7 +34505,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (179,1,1) = {"
 VV
@@ -34666,8 +34513,8 @@ VV
 VV
 VV
 VV
-OF
-OF
+VV
+VV
 VV
 VV
 VV
@@ -34691,18 +34538,18 @@ mS
 UB
 UB
 UB
-aS
-aS
-aS
-aS
-aS
-aS
-aS
 UB
 UB
-aS
-aS
-aS
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
+UB
 UB
 UB
 UB
@@ -34817,7 +34664,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (180,1,1) = {"
 VV
@@ -34976,7 +34823,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (181,1,1) = {"
 VV
@@ -35135,7 +34982,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (182,1,1) = {"
 VV
@@ -35143,9 +34990,9 @@ VV
 VV
 VV
 VV
-OF
 VV
-OF
+VV
+VV
 VV
 VV
 VV
@@ -35294,20 +35141,13 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (183,1,1) = {"
 VV
 VV
 VV
 VV
-OF
-OF
-VV
-VV
-VV
-VV
-OF
 VV
 VV
 VV
@@ -35318,7 +35158,14 @@ VV
 VV
 VV
 VV
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 mS
 mS
@@ -35453,7 +35300,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (184,1,1) = {"
 VV
@@ -35461,11 +35308,11 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
-OF
+VV
+VV
 VV
 VV
 VV
@@ -35612,7 +35459,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (185,1,1) = {"
 VV
@@ -35622,7 +35469,6 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
@@ -35636,26 +35482,27 @@ VV
 VV
 VV
 VV
-OF
-OF
-mS
-dj
-mS
-WG
-NZ
-mS
-dj
-Mo
-Mo
-dj
-Mo
-Mo
-mS
-dj
-dj
+VV
+VV
+VV
 mS
 mS
-dj
+mS
+mS
+UB
+mS
+mS
+mS
+mS
+mS
+mS
+mS
+mS
+mS
+mS
+mS
+mS
+mS
 mS
 mS
 mS
@@ -35771,50 +35618,50 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (186,1,1) = {"
 VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
 VV
-OF
-OF
-OF
-OF
-OF
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 VV
 VV
 mS
 mS
 mS
-dj
-aS
 mS
-dj
+UB
 mS
 mS
-dj
 mS
 mS
-dj
-dj
 mS
-dj
 mS
-Mo
+mS
+mS
+mS
+mS
+mS
+mS
+mS
 mS
 mS
 mS
@@ -35930,30 +35777,30 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (187,1,1) = {"
-OF
 VV
 VV
 VV
-OF
-OF
-OF
-VV
-OF
-OF
 VV
 VV
 VV
-OF
-OF
-OF
-OF
 VV
-OF
 VV
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 VV
 mS
@@ -35963,7 +35810,7 @@ mS
 UB
 mS
 mS
-dj
+mS
 mS
 mS
 mS
@@ -36089,10 +35936,9 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (188,1,1) = {"
-OF
 VV
 VV
 VV
@@ -36112,7 +35958,8 @@ VV
 VV
 VV
 VV
-OF
+VV
+VV
 VV
 VV
 mS
@@ -36248,17 +36095,9 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (189,1,1) = {"
-OF
-VV
-VV
-VV
-VV
-OF
-VV
-OF
 VV
 VV
 VV
@@ -36271,7 +36110,15 @@ VV
 VV
 VV
 VV
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 VV
 mS
@@ -36282,7 +36129,7 @@ UB
 mS
 mS
 mS
-dj
+mS
 mS
 mS
 mS
@@ -36407,20 +36254,9 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (190,1,1) = {"
-OF
-VV
-VV
-VV
-OF
-OF
-VV
-VV
-VV
-VV
-OF
 VV
 VV
 VV
@@ -36430,7 +36266,18 @@ VV
 VV
 VV
 VV
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 VV
 mS
@@ -36566,19 +36413,9 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (191,1,1) = {"
-OF
-VV
-VV
-VV
-VV
-OF
-VV
-VV
-VV
-OF
 VV
 VV
 VV
@@ -36589,7 +36426,17 @@ VV
 VV
 VV
 VV
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 VV
 mS
@@ -36725,7 +36572,7 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (192,1,1) = {"
 VV
@@ -36735,7 +36582,6 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
@@ -36749,7 +36595,8 @@ VV
 VV
 VV
 VV
-OF
+VV
+VV
 VV
 mS
 mS
@@ -36884,19 +36731,9 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (193,1,1) = {"
-OF
-VV
-VV
-VV
-OF
-VV
-VV
-VV
-VV
-OF
 VV
 VV
 VV
@@ -36907,8 +36744,18 @@ VV
 VV
 VV
 VV
-OF
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 mS
 mS
@@ -37043,19 +36890,9 @@ UG
 UG
 UG
 yC
-Sq
+yC
 "}
 (194,1,1) = {"
-OF
-VV
-VV
-VV
-OF
-OF
-OF
-VV
-OF
-OF
 VV
 VV
 VV
@@ -37066,8 +36903,18 @@ VV
 VV
 VV
 VV
-OF
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 mS
 mS
@@ -37205,13 +37052,13 @@ pC
 yC
 "}
 (195,1,1) = {"
-bv
-bv
 VV
 VV
 VV
-OF
-OF
+VV
+VV
+VV
+VV
 VV
 VV
 VV
@@ -37364,7 +37211,6 @@ pC
 yC
 "}
 (196,1,1) = {"
-OF
 VV
 VV
 VV
@@ -37384,8 +37230,9 @@ VV
 VV
 VV
 VV
-OF
-OF
+VV
+VV
+VV
 VV
 mS
 mS
@@ -37536,15 +37383,15 @@ VV
 VV
 VV
 VV
-OF
-bv
-VV
-OF
-OF
-OF
 VV
 VV
-OF
+VV
+VV
+VV
+VV
+VV
+VV
+VV
 VV
 mS
 mS
@@ -37694,16 +37541,16 @@ VV
 VV
 VV
 VV
-OF
 VV
 VV
 VV
-OF
-OF
 VV
 VV
 VV
-OF
+VV
+VV
+VV
+VV
 VV
 mS
 mS

--- a/maps/fairpoint/fairpoint_elevator.dm
+++ b/maps/fairpoint/fairpoint_elevator.dm
@@ -19,7 +19,8 @@
 
 	areas_to_use = list(
 		/area/turbolift/hospital_sewers,
-		/area/turbolift/hospital_surface
+		/area/turbolift/hospital_surface,
+		/area/turbolift/hospital_top
 		)
 
 // DIRECT SEWER ACCESS

--- a/maps/fairpoint/fairpoint_elevator.dm
+++ b/maps/fairpoint/fairpoint_elevator.dm
@@ -1,11 +1,11 @@
 /obj/turbolift_map_holder/fairpoint
 	depth = 2
-	lift_size_x = 3
-	lift_size_y = 3
+	lift_size_x = 4
+	lift_size_y = 4
 
 // POLICE STATION
 /obj/turbolift_map_holder/fairpoint/sec
-	name = "Fairpoint turbolift map placeholder - Security"
+	name = "Fairpoint turbolift map placeholder - Securiy"
 	dir = EAST
 
 	areas_to_use = list(
@@ -19,8 +19,7 @@
 
 	areas_to_use = list(
 		/area/turbolift/hospital_sewers,
-		/area/turbolift/hospital_surface,
-		/area/turbolift/hospital_top
+		/area/turbolift/hospital_surface
 		)
 
 // DIRECT SEWER ACCESS

--- a/maps/fairpoint/fairpoint_elevator.dm
+++ b/maps/fairpoint/fairpoint_elevator.dm
@@ -5,7 +5,7 @@
 
 // POLICE STATION
 /obj/turbolift_map_holder/fairpoint/sec
-	name = "Fairpoint turbolift map placeholder - Securiy"
+	name = "Fairpoint turbolift map placeholder - Security"
 	dir = EAST
 
 	areas_to_use = list(

--- a/maps/fairpoint/newpoint.dmm
+++ b/maps/fairpoint/newpoint.dmm
@@ -295,7 +295,7 @@
 "avI" = (
 /obj/structure/window/borosilicate_reinforced,
 /obj/structure/sealant_injector,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "awe" = (
 /obj/machinery/computer/arcade,
@@ -716,7 +716,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_top)
+/area/fairpoint/police)
 "aVI" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/paleblue{
@@ -1206,11 +1206,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/street/outskirts)
-"bzn" = (
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/turbolift/hospital_sewers)
 "bAb" = (
 /turf/exterior/water,
 /area/fairpoint/shipping/storage)
@@ -1246,7 +1241,7 @@
 /area/fairpoint/medical/medbay)
 "bBK" = (
 /obj/machinery/door/window/southleft,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "bBU" = (
 /obj/machinery/light/small{
@@ -1475,7 +1470,7 @@
 "bQM" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/wall/elevator,
-/area/turbolift/sewer_entrance)
+/area/fairpoint/maintenance/surface)
 "bRa" = (
 /obj/structure/cryofeed,
 /turf/simulated/floor/tiled,
@@ -1741,9 +1736,6 @@
 /area/fairpoint/street/east)
 "ces" = (
 /obj/abstract/level_data/main_level,
-/obj/abstract/map_data{
-	height = 3
-	},
 /turf/simulated/wall/r_wall/hull,
 /area/fairpoint/street/west)
 "cex" = (
@@ -2061,7 +2053,7 @@
 /area/fairpoint/law)
 "cxa" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/cop)
 "cxX" = (
 /obj/structure/table/steel,
@@ -2622,7 +2614,7 @@
 /obj/item/rig/ce/equipped,
 /obj/item/clothing/mask/gas/half,
 /obj/item/tank/oxygen/yellow,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "cZj" = (
 /obj/structure/sign/poster,
@@ -2908,12 +2900,6 @@
 /obj/structure/flora/pottedplant/deskfern,
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/cityhall/hop)
-"djF" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_ground)
 "djU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3200,9 +3186,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/brig)
-"dwF" = (
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_top)
 "dxT" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -3874,7 +3857,7 @@
 /turf/simulated/wall/prepainted{
 	color = "FFFEFD"
 	},
-/area/turbolift/hospital_top)
+/area/fairpoint/medical/medbay)
 "ehU" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -4172,9 +4155,6 @@
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/ebony,
 /area/fairpoint/cityhall/meeting_room)
-"ezl" = (
-/turf/simulated/wall/concrete,
-/area/turbolift/metro_station)
 "ezz" = (
 /obj/effect/floor_decal/corner/grey{
 	tag = "icon-corner_white (NORTH)";
@@ -4322,7 +4302,7 @@
 "eIC" = (
 /obj/structure/sign/warning/fall,
 /turf/simulated/wall/elevator,
-/area/turbolift/pd_top)
+/area/fairpoint/police)
 "eJd" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 9
@@ -4452,11 +4432,6 @@
 	},
 /turf/simulated/floor/wood/ebony,
 /area/fairpoint/street/north)
-"eQV" = (
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/turbolift/hospital_top)
 "eQX" = (
 /obj/effect/floor_decal/corner/grey/border{
 	tag = "icon-bordercolor (WEST)";
@@ -4495,7 +4470,7 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard West"
 	},
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/cop)
 "eUa" = (
 /obj/structure/bed/sofa,
@@ -4585,7 +4560,7 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "feC" = (
 /obj/structure/curtain{
@@ -4903,7 +4878,7 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard West"
 	},
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police)
 "fsi" = (
 /turf/exterior/concrete/pavement,
@@ -5062,7 +5037,7 @@
 /area/fairpoint/medical/medbay)
 "fxX" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police)
 "fyq" = (
 /obj/structure/window/reinforced/tinted{
@@ -5083,9 +5058,9 @@
 /turf/simulated/floor/plating,
 /area/fairpoint/shipping/miningdock)
 "fAp" = (
-/obj/structure/sign/warning,
-/turf/simulated/wall/elevator,
-/area/turbolift/pd_top)
+/obj/abstract/level_data/main_level,
+/turf/simulated/wall/r_wall/hull,
+/area/fairpoint/maintenance/arrivals)
 "fAr" = (
 /obj/machinery/newscaster{
 	pixel_y = 32
@@ -5355,7 +5330,7 @@
 /area/fairpoint/street)
 "fLx" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/armoury)
 "fLA" = (
 /obj/structure/curtain{
@@ -5411,7 +5386,7 @@
 "fOH" = (
 /obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall/concrete,
-/area/turbolift/metro_maintenance)
+/area/fairpoint/hallway/secondary/exit)
 "fOO" = (
 /obj/machinery/light/spot{
 	dir = 8
@@ -5627,9 +5602,6 @@
 "fZQ" = (
 /turf/simulated/floor/tiled,
 /area/fairpoint/shipping/office)
-"gae" = (
-/turf/simulated/wall/elevator,
-/area/turbolift/sewer_exit)
 "gav" = (
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
@@ -5768,7 +5740,7 @@
 /area/fairpoint/street/east)
 "gih" = (
 /turf/simulated/wall/elevator,
-/area/fairpoint/street/west)
+/area/fairpoint/hallway/secondary/exit)
 "giR" = (
 /obj/machinery/light{
 	dir = 1
@@ -5881,7 +5853,7 @@
 /area/turbolift/sewer_exit/mining)
 "gnE" = (
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "gnS" = (
 /obj/machinery/camera/network/security{
@@ -6466,7 +6438,7 @@
 "gUe" = (
 /obj/structure/sign/warning,
 /turf/simulated/wall/elevator,
-/area/turbolift/pd_ground)
+/area/fairpoint/police)
 "gUA" = (
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/tiled/dark,
@@ -6751,9 +6723,6 @@
 	},
 /turf/simulated/floor/tiled/old_cargo,
 /area/fairpoint/shipping/storage)
-"hlf" = (
-/turf/simulated/floor/tiled/monofloor,
-/area/fairpoint/street)
 "hll" = (
 /obj/structure/bed/sofa{
 	dir = 9
@@ -7054,7 +7023,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
-/area/turbolift/metro_maintenance)
+/area/fairpoint/hallway/secondary/exit)
 "hAE" = (
 /obj/structure/table/reinforced,
 /obj/effect/floor_decal/corner/paleblue{
@@ -7262,9 +7231,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/cmo)
-"hNC" = (
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_ground)
 "hNI" = (
 /obj/effect/wallframe_spawn/reinforced/bare,
 /turf/simulated/floor,
@@ -9321,7 +9287,7 @@
 	},
 /area/fairpoint/medical/patient_b)
 "kaB" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police)
 "kbf" = (
 /obj/effect/floor_decal/corner/pink/bordercorner{
@@ -9551,7 +9517,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_top)
+/area/fairpoint/police)
 "kqO" = (
 /obj/structure/bed/chair{
 	dir = 8
@@ -10153,7 +10119,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/cityhall)
 "kVN" = (
-/turf/unsimulated/mask,
+/turf/simulated/open,
 /area/turbolift/sewer_entrance)
 "kWF" = (
 /turf/exterior/wildgrass,
@@ -10424,7 +10390,7 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/hydroponics)
 "loh" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/cop)
 "lol" = (
 /obj/item/clothing/head/welding,
@@ -10592,7 +10558,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/shipping/qm)
 "lwc" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "lwm" = (
 /obj/machinery/light_switch{
@@ -10636,7 +10602,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "lxL" = (
 /obj/structure/flora/pottedplant{
@@ -10848,7 +10814,7 @@
 	dir = 8
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/stone,
+/turf/exterior/concrete,
 /area/fairpoint/street/west)
 "lKi" = (
 /turf/simulated/wall/r_wall,
@@ -11030,7 +10996,7 @@
 /turf/simulated/floor/wood/maple,
 /area/fairpoint/library)
 "lWz" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/prison)
 "lWB" = (
 /obj/effect/wingrille_spawn/reinforced,
@@ -12068,7 +12034,7 @@
 /area/fairpoint/research/robotics)
 "ngj" = (
 /obj/machinery/porta_turret,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/prison)
 "ngv" = (
 /turf/simulated/floor/tiled/white,
@@ -12495,8 +12461,10 @@
 /turf/simulated/floor,
 /area/fairpoint/medical/medbay)
 "nFK" = (
-/turf/simulated/wall/elevator,
-/area/turbolift/pd_top)
+/obj/structure/ladder,
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/fairpoint/cityhall)
 "nGe" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 8
@@ -12590,7 +12558,7 @@
 /area/fairpoint/crew_quarters/medbreak)
 "nLf" = (
 /obj/machinery/door/airlock/glass/civilian,
-/turf/simulated/floor/tiled/monofloor,
+/turf/exterior/concrete/pavement/brick_paving,
 /area/fairpoint/street)
 "nLP" = (
 /obj/structure/window/basic{
@@ -12695,7 +12663,7 @@
 "nTB" = (
 /obj/structure/sign/warning/moving_parts,
 /turf/simulated/wall/elevator,
-/area/turbolift/pd_ground)
+/area/fairpoint/police)
 "nTD" = (
 /obj/structure/flora/pottedplant{
 	pixel_y = 10
@@ -13016,15 +12984,12 @@
 /area/fairpoint/research/server)
 "olL" = (
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "omh" = (
 /obj/machinery/door/airlock/vault,
 /turf/simulated/floor/reinforced,
 /area/fairpoint/panicroom)
-"omu" = (
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_sewers)
 "omM" = (
 /obj/machinery/camera/network/research{
 	dir = 8;
@@ -13372,15 +13337,6 @@
 /obj/machinery/disposal,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/reception)
-"oHA" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_ground)
 "oHE" = (
 /obj/structure/bed/chair/armchair/green{
 	dir = 1
@@ -13704,9 +13660,6 @@
 "oVb" = (
 /turf/exterior/concrete/reinforced/road,
 /area/fairpoint/street/north)
-"oVc" = (
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_surface)
 "oVM" = (
 /obj/structure/table/woodentable,
 /obj/item/glass_jar,
@@ -14272,9 +14225,6 @@
 	},
 /turf/exterior/concrete/pavement/empty,
 /area/fairpoint/street)
-"pBu" = (
-/turf/simulated/wall/elevator,
-/area/turbolift/pd_ground)
 "pBW" = (
 /obj/structure/railing{
 	dir = 1
@@ -14396,9 +14346,6 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/morgue)
-"pHZ" = (
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_top)
 "pJa" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/item/clothing/under/color/white,
@@ -14981,7 +14928,7 @@
 /turf/simulated/floor/wood,
 /area/fairpoint/library)
 "qku" = (
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/armoury)
 "qkA" = (
 /turf/simulated/floor/tiled/dark,
@@ -15516,10 +15463,6 @@
 /obj/item/modular_computer/laptop/preset/records,
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/crew_quarters/mayor)
-"qHp" = (
-/obj/structure/lift/button,
-/turf/simulated/wall/concrete,
-/area/turbolift/metro_maintenance)
 "qHq" = (
 /obj/structure/sign/warning/nosmoking_1,
 /turf/simulated/wall/prepainted{
@@ -15738,9 +15681,6 @@
 	color = "FFFEFD"
 	},
 /area/fairpoint/medical/surgery)
-"qQA" = (
-/turf/simulated/floor/tiled/steel_grid,
-/area/turbolift/sewer_exit)
 "qQP" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -16326,8 +16266,8 @@
 	},
 /area/fairpoint/medical/psych)
 "rxV" = (
-/turf/simulated/wall/iron,
-/area/turbolift/sewer_exit)
+/turf/simulated/open,
+/area/fairpoint/crew_quarters/bar)
 "rya" = (
 /obj/machinery/door/airlock/glass/security,
 /turf/simulated/floor/tiled/monotile,
@@ -16618,7 +16558,7 @@
 /area/fairpoint/police/detectives_office)
 "rRM" = (
 /obj/structure/window/borosilicate_reinforced,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "rRO" = (
 /obj/structure/bed/sofa{
@@ -16769,7 +16709,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "rXg" = (
 /obj/effect/wingrille_spawn/reinforced,
@@ -17126,7 +17066,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_ground)
+/area/fairpoint/police)
 "stB" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/box/flashbangs,
@@ -17399,12 +17339,6 @@
 /obj/random/trash,
 /turf/exterior/concrete/pavement/empty,
 /area/fairpoint/street/east)
-"sHL" = (
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/turbolift/metro_station)
 "sIa" = (
 /obj/structure/bed/chair{
 	dir = 4
@@ -17734,7 +17668,7 @@
 /obj/structure/sealant_rack,
 /obj/item/gun/launcher/sealant,
 /obj/machinery/camera/network/engineering,
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/engineering/ce)
 "sWV" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -18623,11 +18557,6 @@
 /obj/structure/flora/pottedplant/deskleaf,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/psych)
-"tVj" = (
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/turbolift/hospital_surface)
 "tVu" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -21697,10 +21626,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/shipping/storage)
-"xnx" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/carpet,
-/area/turbolift/sewer_entrance)
 "xny" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -21739,12 +21664,6 @@
 /obj/item/storage/box/evidence,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/detectives_office)
-"xpr" = (
-/obj/structure/sign/warning,
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/turbolift/hospital_sewers)
 "xpz" = (
 /turf/exterior/concrete/pavement/stairs,
 /area/fairpoint/street)
@@ -21838,7 +21757,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/shipping/miningdock)
 "xvl" = (
-/turf/exterior/open,
+/turf/simulated/open,
 /area/fairpoint/medical/medbay)
 "xvB" = (
 /obj/machinery/atm{
@@ -22252,7 +22171,7 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard West"
 	},
-/turf/simulated/floor/tiled/monofloor,
+/turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/police/prison)
 "xRn" = (
 /turf/simulated/wall/r_wall,
@@ -22316,11 +22235,12 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "xUG" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
+/obj/abstract/map_data{
+	height = 3
 	},
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_top)
+/obj/abstract/level_data/main_level,
+/turf/simulated/wall/concrete,
+/area/fairpoint/street/outskirts)
 "xUH" = (
 /obj/structure/bed/chair/armchair/purple{
 	dir = 1
@@ -22846,7 +22766,7 @@ ylv
 ylv
 ylv
 ylv
-ylv
+fAp
 "}
 (2,1,1) = {"
 wEt
@@ -28678,7 +28598,7 @@ dpT
 dpT
 dpT
 qBc
-qHp
+qBc
 hzp
 hzp
 hzp
@@ -38555,12 +38475,12 @@ nlo
 lFO
 pjG
 ieA
-xpr
-bzn
-bzn
-bzn
-bzn
-bzn
+ehr
+oTt
+oTt
+oTt
+oTt
+oTt
 jsW
 nLU
 ieA
@@ -38714,7 +38634,7 @@ nlo
 lBO
 ale
 spP
-bzn
+oTt
 lUA
 lUA
 lUA
@@ -38873,7 +38793,7 @@ vxu
 qHq
 wJa
 jmw
-omu
+ale
 lUA
 lUA
 lUA
@@ -39032,7 +38952,7 @@ pCL
 pCL
 uzP
 jmw
-omu
+ale
 lUA
 lUA
 lUA
@@ -39191,7 +39111,7 @@ vxu
 iLD
 ygv
 jmw
-omu
+ale
 lUA
 lUA
 lUA
@@ -39350,7 +39270,7 @@ nlo
 lFO
 tAK
 wsV
-bzn
+oTt
 lUA
 lUA
 lUA
@@ -51690,7 +51610,7 @@ qXt
 qXt
 qXt
 bFp
-gae
+xoO
 xoO
 dpT
 dpT
@@ -51849,7 +51769,7 @@ qXt
 qXt
 qXt
 qXt
-gae
+xoO
 xoO
 dpT
 dpT
@@ -52008,7 +51928,7 @@ qXt
 qXt
 qXt
 qXt
-gae
+xoO
 dpT
 dpT
 dpT
@@ -52167,7 +52087,7 @@ qXt
 qXt
 qXt
 qXt
-gae
+xoO
 dpT
 dpT
 dpT
@@ -52326,7 +52246,7 @@ uEX
 uEX
 uEX
 uEX
-gae
+xoO
 dpT
 dpT
 dpT
@@ -52480,12 +52400,12 @@ dpT
 bIo
 bIo
 xoO
-rxV
-qQA
-qXt
-qXt
-rxV
-rxV
+dpT
+oUU
+jbX
+jbX
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -57170,25 +57090,25 @@ eJq
 eJq
 eJq
 rCq
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
 gnE
 nsJ
 eBe
@@ -57343,11 +57263,11 @@ eJq
 rps
 rps
 rps
-xSS
-xSS
+rhj
+rhj
 cnG
-xSS
-xSS
+rhj
+rhj
 wjX
 nsJ
 eBe
@@ -57502,11 +57422,11 @@ eJq
 rps
 tmL
 rps
-xSS
-xSS
+rhj
+rhj
 aNS
-xSS
-xSS
+rhj
+rhj
 wjX
 nsJ
 eBe
@@ -57661,11 +57581,11 @@ eJq
 rps
 rps
 rps
-xSS
-xSS
+rhj
+rhj
 cnG
-xSS
-xSS
+rhj
+rhj
 wjX
 nsJ
 eBe
@@ -57806,25 +57726,25 @@ eJq
 eJq
 eJq
 pOG
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
 gnE
 nsJ
 eBe
@@ -57965,25 +57885,25 @@ eJq
 eJq
 eJq
 rCq
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
 gnE
 nsJ
 eBe
@@ -58138,11 +58058,11 @@ eJq
 eJq
 eJq
 eJq
-xSS
-xSS
+rhj
+rhj
 eJq
-xSS
-xSS
+rhj
+rhj
 dQU
 nsJ
 eBe
@@ -58297,11 +58217,11 @@ eZs
 eZs
 eZs
 eZs
-xSS
-xSS
+rhj
+rhj
 pNS
-xSS
-xSS
+rhj
+rhj
 dQU
 nsJ
 eBe
@@ -58456,11 +58376,11 @@ eZs
 eZs
 eZs
 eZs
-xSS
-xSS
+rhj
+rhj
 fah
-xSS
-xSS
+rhj
+rhj
 dQU
 nsJ
 eBe
@@ -58602,24 +58522,24 @@ lkI
 cSi
 hTN
 eZs
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
 pNS
-xSS
-xSS
+rhj
+rhj
 dQU
 nsJ
 eBe
@@ -58761,24 +58681,24 @@ pNB
 cMw
 hTN
 lRy
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
-xSS
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
+rhj
 fah
-xSS
-xSS
+rhj
+rhj
 dQU
 nsJ
 eBe
@@ -58920,7 +58840,7 @@ pNB
 cMw
 hTN
 eZs
-xSS
+rhj
 eZs
 qNI
 eZs
@@ -58933,8 +58853,8 @@ fah
 fah
 fah
 fah
-xSS
-xSS
+rhj
+rhj
 fEB
 dBI
 qjf
@@ -59092,8 +59012,8 @@ fdG
 fdG
 fdG
 lKd
-xSS
-xSS
+rhj
+rhj
 lxI
 fdG
 fdG
@@ -60479,12 +60399,12 @@ eJq
 eJq
 eJq
 qBc
-ezl
-sHL
-sHL
-sHL
-ezl
-nsJ
+qBc
+hzp
+hzp
+hzp
+qBc
+qBc
 nsJ
 hYI
 nsJ
@@ -66748,11 +66668,11 @@ kaB
 kaB
 fxX
 lqs
-pBu
-pBu
-pBu
-pBu
-pBu
+qQV
+qQV
+qQV
+qQV
+qQV
 nTB
 sty
 xoA
@@ -66912,8 +66832,8 @@ ezz
 hZR
 hZR
 xJp
-pBu
-oHA
+qQV
+kqI
 xoA
 mXe
 hwc
@@ -67071,8 +66991,8 @@ wIN
 wIN
 wIN
 wIN
-hNC
-djF
+xoA
+aVC
 xoA
 sqN
 jcL
@@ -67230,8 +67150,8 @@ msl
 msl
 msl
 msl
-hNC
-djF
+xoA
+aVC
 xoA
 xoA
 xoA
@@ -67318,7 +67238,7 @@ ncZ
 iRJ
 fUf
 fUf
-hlf
+oft
 nLf
 oft
 oft
@@ -67389,8 +67309,8 @@ ezz
 hZR
 ezz
 jzJ
-hNC
-djF
+xoA
+aVC
 xoA
 cPe
 ahZ
@@ -67477,7 +67397,7 @@ ncZ
 iRJ
 fUf
 fUf
-hlf
+oft
 nLf
 oft
 oft
@@ -67548,8 +67468,8 @@ ezz
 hZR
 hZR
 jzJ
-pBu
-oHA
+qQV
+kqI
 xoA
 mXe
 xII
@@ -67702,11 +67622,11 @@ szv
 ncP
 kaB
 lqs
-pBu
-pBu
-pBu
-pBu
-pBu
+qQV
+qQV
+qQV
+qQV
+qQV
 gUe
 sty
 oqG
@@ -70356,12 +70276,12 @@ hdt
 qQv
 pjG
 ieA
-tVj
-tVj
-tVj
-tVj
-tVj
-tVj
+oTt
+oTt
+oTt
+oTt
+oTt
+oTt
 jsW
 aac
 ale
@@ -70515,7 +70435,7 @@ dfl
 wHk
 ale
 spP
-tVj
+oTt
 lLd
 lLd
 lLd
@@ -70674,7 +70594,7 @@ pac
 qfr
 aac
 jmw
-oVc
+ale
 lLd
 lLd
 lLd
@@ -70833,7 +70753,7 @@ qou
 qQv
 uzP
 jmw
-oVc
+ale
 lLd
 lLd
 lLd
@@ -70992,7 +70912,7 @@ adF
 rlj
 ygv
 jmw
-oVc
+ale
 lLd
 lLd
 lLd
@@ -71151,7 +71071,7 @@ kPh
 adF
 pjG
 wsV
-tVj
+oTt
 lLd
 lLd
 lLd
@@ -84282,9 +84202,9 @@ qsa
 itW
 doX
 bQM
-xnx
-xnx
-xnx
+vHx
+vHx
+vHx
 bQM
 iZi
 gcT
@@ -86448,7 +86368,7 @@ elf
 elf
 elf
 vvE
-vvE
+xUG
 "}
 (2,1,3) = {"
 fGj
@@ -98549,13 +98469,13 @@ wUR
 wUR
 wUR
 tCz
-nFK
-nFK
-nFK
-nFK
-nFK
+qQV
+qQV
+qQV
+qQV
+qQV
 eIC
-xUG
+sty
 xoA
 mXe
 hwc
@@ -98713,7 +98633,7 @@ tTx
 tTx
 tTx
 tTx
-nFK
+qQV
 kqI
 xoA
 mXe
@@ -98872,7 +98792,7 @@ tTx
 tTx
 tTx
 tTx
-dwF
+xoA
 aVC
 xoA
 mXe
@@ -99031,7 +98951,7 @@ tTx
 tTx
 tTx
 tTx
-dwF
+xoA
 aVC
 xoA
 sqN
@@ -99190,7 +99110,7 @@ tTx
 tTx
 tTx
 tTx
-dwF
+xoA
 aVC
 xoA
 cPe
@@ -99349,7 +99269,7 @@ tTx
 tTx
 tTx
 tTx
-nFK
+qQV
 kqI
 xoA
 mXe
@@ -99503,13 +99423,13 @@ ncP
 ncP
 ncP
 qQV
-nFK
-nFK
-nFK
-nFK
-nFK
-fAp
-xUG
+qQV
+qQV
+qQV
+qQV
+qQV
+gUe
+sty
 aqZ
 oSq
 xII
@@ -99703,7 +99623,7 @@ bcr
 elf
 brw
 hOq
-vSI
+nFK
 pVO
 tLz
 tLz
@@ -102158,11 +102078,11 @@ nVj
 ale
 ieA
 ehr
-eQV
-eQV
-eQV
-eQV
-eQV
+oTt
+oTt
+oTt
+oTt
+oTt
 eJK
 aAq
 aAq
@@ -102316,7 +102236,7 @@ uaa
 ale
 ale
 spP
-eQV
+oTt
 gKY
 gKY
 gKY
@@ -102475,7 +102395,7 @@ lXk
 gQP
 ale
 jmw
-pHZ
+ale
 gKY
 gKY
 gKY
@@ -102634,7 +102554,7 @@ kGi
 nLU
 ale
 jmw
-pHZ
+ale
 gKY
 gKY
 gKY
@@ -102793,7 +102713,7 @@ kGi
 nLU
 ale
 jmw
-pHZ
+ale
 gKY
 gKY
 gKY
@@ -102952,7 +102872,7 @@ lXk
 vqg
 ale
 wsV
-eQV
+oTt
 gKY
 gKY
 gKY
@@ -106427,13 +106347,13 @@ rku
 rku
 rku
 jyH
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 jyH
 jyH
@@ -106586,15 +106506,15 @@ rku
 rku
 rku
 jyH
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -106745,15 +106665,15 @@ rku
 rku
 rku
 jyH
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -106904,15 +106824,15 @@ rku
 rku
 rku
 jyH
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -107063,15 +106983,15 @@ jyH
 jyH
 jyH
 jyH
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -107222,15 +107142,15 @@ nrO
 nrO
 nrO
 bpX
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -107381,15 +107301,15 @@ nrO
 nrO
 nrO
 bpX
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -107540,15 +107460,15 @@ nrO
 nrO
 nrO
 bpX
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -107699,15 +107619,15 @@ nrO
 nrO
 nrO
 bpX
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -107858,15 +107778,15 @@ nrO
 nrO
 nrO
 bpX
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr
@@ -108017,15 +107937,15 @@ tri
 tri
 tri
 bpX
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
-qty
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
+rxV
 jyH
 bcr
 bcr

--- a/maps/fairpoint/newpoint.dmm
+++ b/maps/fairpoint/newpoint.dmm
@@ -5,12 +5,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
-"aan" = (
-/obj/structure/disposalpipe/junction/yjunction{
-	dir = 1
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "aax" = (
 /obj/structure/closet/crate,
 /obj/item/stack/cable_coil/random,
@@ -514,13 +508,6 @@
 	},
 /turf/exterior/concrete/pavement/brick_paving,
 /area/fairpoint/street)
-"aJw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "aJA" = (
 /obj/machinery/vending/assist,
 /obj/effect/floor_decal/industrial/warning{
@@ -649,11 +636,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/exterior/concrete/pavement/empty,
 /area/fairpoint/street/east)
-"aOE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "aOF" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -774,12 +756,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/fairpoint/medical/patient_wing)
-"aYT" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "aYY" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/dark,
@@ -824,12 +800,6 @@
 "beB" = (
 /turf/simulated/wall/r_wall/hull,
 /area/fairpoint/street)
-"beM" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "bgt" = (
 /obj/structure/plushie/beepsky,
 /obj/machinery/recharger,
@@ -853,6 +823,7 @@
 /obj/structure/window/reinforced/full{
 	color = "#cc6699"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/crew_quarters/bar)
 "bhO" = (
@@ -980,7 +951,6 @@
 	icon_state = "shutter0";
 	name = "Magistrate Shutters"
 	},
-/obj/structure/grille,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/fairpoint/law/judge)
@@ -1111,12 +1081,6 @@
 /obj/item/chems/ivbag/blood/APlus,
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/biostorage)
-"bsQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "bsS" = (
 /obj/structure/table/glass,
 /obj/item/modular_computer/telescreen/preset/medical,
@@ -1517,11 +1481,6 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/crew_quarters/sleep/cryo)
 "bRq" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -2115,16 +2074,8 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/brig)
-"cyw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet{
-	name = "Evidence Closet"
-	},
-/turf/simulated/floor/reinforced,
-/area/fairpoint/police/cop)
 "cyz" = (
 /obj/effect/floor_decal/floordetail/pryhole,
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "czi" = (
@@ -2195,13 +2146,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled,
 /area/fairpoint/cityhall)
-"cDP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "cDU" = (
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/surface)
@@ -2316,12 +2260,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/vacantoffice)
-"cJx" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/turf/exterior/concrete/pavement/empty,
-/area/fairpoint/street/west)
 "cJz" = (
 /obj/effect/floor_decal/corner/lightgrey{
 	tag = "icon-corner_white (SOUTHWEST)";
@@ -2443,7 +2381,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -2452,11 +2389,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "cNR" = (
 /obj/effect/catwalk_plated,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/fairpoint/hallway/secondary/exit)
 "cNS" = (
@@ -2582,14 +2519,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/brig)
-"cTV" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/fairpoint/police/prison)
 "cTY" = (
 /obj/effect/floor_decal/corner/white{
 	tag = "icon-corner_white (EAST)";
@@ -2674,6 +2603,7 @@
 /obj/structure/window/reinforced/full{
 	color = "#CCCC7A"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/street/east)
 "cZd" = (
@@ -2877,13 +2807,6 @@
 /mob/living/simple_animal/mouse/gray,
 /turf/exterior/concrete/pavement/pave_tiling,
 /area/fairpoint/street/east)
-"deP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "dfl" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -3423,16 +3346,6 @@
 /obj/structure/holostool,
 /turf/simulated/floor/carpet,
 /area/fairpoint/chapel/main)
-"dCi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	tag = "icon-bordercolor (WEST)";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "dCU" = (
 /obj/structure/closet/wardrobe/virology_white,
 /obj/effect/floor_decal/corner/green{
@@ -3611,10 +3524,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/fairpoint/police/detectives_office)
-"dPA" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "dQa" = (
 /obj/structure/window/reinforced,
 /obj/effect/floor_decal/spline/fancy,
@@ -3696,14 +3605,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
-"dSC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1;
-	tag = "icon-warning_dust (NORTH)"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "dSP" = (
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/dark,
@@ -4046,7 +3947,6 @@
 	icon_state = "shutter0";
 	name = "Magistrate Shutters"
 	},
-/obj/structure/grille,
 /obj/effect/wingrille_spawn/reinforced/polarized,
 /turf/simulated/floor/tiled,
 /area/fairpoint/law/judge)
@@ -4138,15 +4038,8 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/vacantoffice)
 "erR" = (
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	icon_state = "shutter0";
-	name = "Magistrate Shutters"
-	},
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/tiled,
-/area/fairpoint/law/judge)
+/turf/unsimulated/mask,
+/area/fairpoint/street/outskirts)
 "erV" = (
 /obj/structure/bookcase{
 	name = "bookcase (Fiction)"
@@ -4614,16 +4507,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/engineering/break_room)
-"eVz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/grey/border{
-	tag = "icon-bordercolor (WEST)";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "eVB" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/morgue)
@@ -4704,12 +4587,6 @@
 	},
 /turf/simulated/floor/tiled/stone,
 /area/fairpoint/street/west)
-"fdH" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 4
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "feC" = (
 /obj/structure/curtain{
 	color = "#4C0000";
@@ -5765,7 +5642,6 @@
 /area/fairpoint/police/main)
 "gaO" = (
 /obj/machinery/vending/lavatory,
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/cityhall)
 "gba" = (
@@ -6275,13 +6151,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
-"gFy" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "gFN" = (
 /turf/simulated/wall/concrete{
 	color = "#FFFEFD"
@@ -6385,7 +6254,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/brig)
 "gKO" = (
-/obj/effect/wingrille_spawn/reinforced/polarized,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/meeting)
@@ -6406,11 +6274,6 @@
 /obj/machinery/camera/network/security{
 	c_tag = "SEC - Prison Courtyard East";
 	dir = 9
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
 	},
 /obj/structure/table/reinforced,
 /obj/item/storage/box/gloves,
@@ -6519,7 +6382,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -6527,6 +6389,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "gQK" = (
@@ -6623,9 +6486,7 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police/vacantoffice)
 "gWr" = (
-/obj/structure/catwalk,
 /obj/effect/catwalk_plated,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/fairpoint/maintenance/arrivals)
 "gXA" = (
@@ -6828,9 +6689,6 @@
 /turf/simulated/floor/wood/usedup,
 /area/fairpoint/street/east)
 "hiC" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1;
 	tag = "icon-warning_dust (NORTH)"
@@ -6981,7 +6839,12 @@
 /turf/simulated/floor/carpet,
 /area/fairpoint/police/detectives_office)
 "hoL" = (
-/turf/space,
+/obj/turbolift_map_holder/fairpoint{
+	dir = 4;
+	lift_size_x = 3;
+	lift_size_y = 3
+	},
+/turf/simulated/floor/wood/usedup,
 /area/fairpoint/street/east)
 "hpj" = (
 /obj/structure/table/reinforced,
@@ -7080,13 +6943,6 @@
 "htF" = (
 /turf/exterior/concrete/pavement/stairs,
 /area/fairpoint/street/east)
-"htU" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/turf/simulated/floor/wood/ebony,
-/area/fairpoint/police/cop)
 "huf" = (
 /turf/exterior/barren,
 /area/fairpoint/street/west)
@@ -7331,12 +7187,6 @@
 "hIJ" = (
 /turf/exterior/open,
 /area/fairpoint/street/west)
-"hJr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "hJx" = (
 /obj/machinery/computer/account_database,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -7376,11 +7226,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/prison)
-"hLz" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/street)
 "hLE" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/reception)
@@ -7436,11 +7281,6 @@
 /turf/simulated/floor/wood/yew,
 /area/fairpoint/cityhall)
 "hOq" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/window/reinforced{
 	dir = 1;
 	health = 1e+006
@@ -7760,15 +7600,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
-"igS" = (
-/obj/structure/table/reinforced,
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/fairpoint/police/detectives_office)
 "ihp" = (
 /obj/effect/floor_decal/carpet/blue2{
 	dir = 4
@@ -7805,10 +7636,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/chapel/main)
-"iiM" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/fairpoint/crew_quarters/bar)
 "ikf" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
@@ -8139,11 +7966,6 @@
 /turf/simulated/wall/r_wall,
 /area/fairpoint/cityhall)
 "iEl" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
 /obj/effect/floor_decal/corner/paleblue/full{
 	tag = "icon-corner_white_full (EAST)";
 	dir = 4
@@ -8441,7 +8263,6 @@
 /area/fairpoint/street)
 "iTu" = (
 /obj/effect/wallframe_spawn/reinforced,
-/obj/effect/wingrille_spawn/reinforced_borosilicate,
 /turf/simulated/floor,
 /area/fairpoint/turret_protected/ai_server_room)
 "iTE" = (
@@ -8636,10 +8457,6 @@
 "jdH" = (
 /turf/simulated/floor/wood,
 /area/fairpoint/library)
-"jdO" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "jdS" = (
 /obj/effect/floor_decal/corner/orange{
 	tag = "icon-corner_white (SOUTHEAST)";
@@ -8788,11 +8605,6 @@
 /obj/effect/wingrille_spawn/reinforced_borosilicate,
 /turf/simulated/floor/blackgrid,
 /area/fairpoint/turret_protected/ai_server_room)
-"jml" = (
-/obj/structure/catwalk,
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "jmm" = (
 /obj/effect/floor_decal/corner/paleblue,
 /obj/effect/floor_decal/corner/white{
@@ -9099,11 +8911,6 @@
 /obj/machinery/vending/coffee,
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/street/north)
-"jBM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/wall,
-/area/fairpoint/street)
 "jCe" = (
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer,
@@ -9242,10 +9049,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/shipping/office)
-"jJU" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/street)
 "jKr" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -10134,13 +9937,6 @@
 /obj/item/stamp/denied,
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/cityhall/hop)
-"kLk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "kLy" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/monotile,
@@ -10403,14 +10199,6 @@
 	},
 /turf/exterior/concrete/pavement/pave_tiling,
 /area/fairpoint/street/north)
-"kZv" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/wall/elevator,
-/area/turbolift/pd_top)
 "kZA" = (
 /obj/item/clothing/under/dress/dress_green,
 /obj/structure/coatrack,
@@ -10661,12 +10449,6 @@
 	},
 /turf/exterior/concrete/reinforced/road,
 /area/fairpoint/shipping/office)
-"loW" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/bed/padded,
-/obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled/dark,
-/area/fairpoint/police/prison/dorm)
 "lpb" = (
 /obj/effect/floor_decal/corner/pink{
 	tag = "icon-corner_white (SOUTHEAST)";
@@ -10890,36 +10672,10 @@
 /obj/structure/filingcabinet/chestdrawer,
 /turf/simulated/floor/wood/ebony,
 /area/fairpoint/crew_quarters/mayor)
-"lAq" = (
-/obj/structure/grille,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 4;
-	icon_state = "intact";
-	tag = "icon-intact-f (EAST)"
-	},
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/greengrid,
-/area/fairpoint/research/server)
 "lAE" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/range)
-"lAN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "lAS" = (
 /obj/structure/disposalpipe/broken,
 /obj/structure/grille/broken,
@@ -10999,14 +10755,6 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/tiled,
 /area/fairpoint/shipping/office)
-"lFh" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/fairpoint/police/armoury)
 "lFn" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 4
@@ -11088,19 +10836,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/prison)
-"lJa" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/simulated/floor,
-/area/fairpoint/shipping/miningdock)
 "lJc" = (
 /obj/machinery/door/airlock/glass/medical,
 /turf/simulated/floor/tiled/white,
@@ -11234,14 +10969,6 @@
 	},
 /turf/exterior/dirt,
 /area/fairpoint/street/west)
-"lRJ" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/reinforced,
-/area/fairpoint/police/cop)
 "lSb" = (
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -11392,7 +11119,6 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/research/robotics)
 "mbS" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock/glass/security,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/prison/dorm)
@@ -11658,7 +11384,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "mpt" = (
-/obj/structure/grille,
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	icon_state = "shutter0";
@@ -11749,7 +11474,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/lobby)
 "mtX" = (
-/obj/structure/grille,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -11766,6 +11490,7 @@
 	name = "Biohazard Shutter";
 	opacity = 0
 	},
+/obj/structure/grille,
 /turf/simulated/floor/tiled,
 /area/fairpoint/research/robotics)
 "muc" = (
@@ -11868,10 +11593,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/carpet,
 /area/fairpoint/chapel/office)
-"mzt" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/open,
-/area/fairpoint/street)
 "mzU" = (
 /obj/structure/filingcabinet,
 /turf/simulated/floor/tiled,
@@ -12319,12 +12040,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/shipping/miningdock)
-"neJ" = (
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "neW" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/welding/superior,
@@ -12557,21 +12272,6 @@
 	dir = 8
 	},
 /area/fairpoint/hydroponics/garden)
-"ntF" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "SEC - Brig Starboard";
-	dir = 9
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/dark,
-/area/fairpoint/police)
 "ntQ" = (
 /obj/machinery/door/blast/shutters{
 	density = 0;
@@ -12650,15 +12350,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/police/vacantoffice)
-"nyJ" = (
-/obj/effect/floor_decal/corner/blue/diagonal,
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/turf/simulated/floor/tiled/techfloor,
-/area/fairpoint/police/brig/interrogation)
 "nyV" = (
 /obj/effect/floor_decal/corner/blue/border,
 /turf/simulated/floor/tiled/white,
@@ -12686,7 +12377,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -12694,6 +12384,7 @@
 	dir = 4
 	},
 /obj/structure/window/reinforced,
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "nAM" = (
@@ -12975,10 +12666,6 @@
 "nQY" = (
 /turf/exterior/concrete/pavement/corner,
 /area/fairpoint/hydroponics/garden)
-"nRs" = (
-/obj/structure/disposalpipe/segment,
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "nRP" = (
 /obj/machinery/bodyscanner,
 /turf/simulated/floor/tiled/white,
@@ -13198,10 +12885,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/sleeper)
-"oeL" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/walnut,
-/area/fairpoint/street/outskirts)
 "oeX" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
 /obj/effect/floor_decal/corner/paleblue/border{
@@ -13295,16 +12978,6 @@
 /obj/structure/table/glass,
 /turf/simulated/floor/tiled,
 /area/fairpoint/crew_quarters/medbreak)
-"ojh" = (
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	icon_state = "shutter0";
-	name = "Prosecution Shutters"
-	},
-/obj/structure/grille,
-/obj/effect/wingrille_spawn/reinforced,
-/turf/simulated/floor/tiled,
-/area/fairpoint/law/lawoffice)
 "ojD" = (
 /obj/structure/bed/sofa{
 	dir = 6
@@ -13527,12 +13200,6 @@
 	},
 /turf/simulated/floor/carpet,
 /area/fairpoint/cityhall/meeting_room)
-"owf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "owp" = (
 /obj/machinery/atm{
 	name = "ATM";
@@ -13944,12 +13611,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police)
-"oSy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/street)
 "oST" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -14092,6 +13753,7 @@
 /obj/structure/window/reinforced/full{
 	color = "#CCCC7A"
 	},
+/obj/structure/grille,
 /turf/simulated/floor/wood/usedup,
 /area/fairpoint/street/east)
 "oZx" = (
@@ -14198,10 +13860,6 @@
 	},
 /turf/exterior/concrete/pavement/stairs,
 /area/fairpoint/law)
-"pdB" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled/steel_ridged,
-/area/fairpoint/maintenance/arrivals)
 "pee" = (
 /obj/structure/table/woodentable,
 /turf/simulated/floor/tiled/stone,
@@ -14348,10 +14006,6 @@
 /area/fairpoint/crew_quarters/kitchen)
 "pkB" = (
 /turf/exterior/concrete/pavement/corner,
-/area/fairpoint/street)
-"pkY" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/wall,
 /area/fairpoint/street)
 "plf" = (
 /obj/structure/window/reinforced{
@@ -15347,10 +15001,6 @@
 /obj/machinery/vitals_monitor,
 /turf/simulated/floor/tiled,
 /area/fairpoint/medical/sleeper)
-"qkS" = (
-/obj/structure/disposalpipe/segment,
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "qlp" = (
 /obj/machinery/vending/robotics,
 /turf/simulated/floor/tiled,
@@ -15416,10 +15066,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/fairpoint/street/east)
-"qnt" = (
-/obj/structure/catwalk,
-/turf/simulated/floor,
-/area/fairpoint/maintenance/arrivals)
 "qnv" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15477,7 +15123,6 @@
 	name = "Test Chamber Blast Doors";
 	opacity = 0
 	},
-/obj/structure/grille,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -15485,6 +15130,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
+/obj/structure/grille,
 /turf/simulated/floor/plating,
 /area/fairpoint/research/misc_lab)
 "qqg" = (
@@ -15756,16 +15402,6 @@
 /obj/item/disk/design_disk,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/engineering/sysadmin)
-"qzb" = (
-/obj/structure/grille,
-/obj/machinery/door/blast/shutters{
-	dir = 2;
-	icon_state = "shutter0";
-	name = "Magistrate Shutters"
-	},
-/obj/effect/wingrille_spawn/reinforced/polarized,
-/turf/simulated/floor/tiled,
-/area/fairpoint/law/judge)
 "qzs" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
@@ -15778,9 +15414,6 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/law)
 "qzM" = (
-/obj/effect/floor_decal/industrial/warning{
-	dir = 1
-	},
 /obj/random/trash,
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1;
@@ -15878,11 +15511,6 @@
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
-"qFn" = (
-/obj/effect/catwalk_plated,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/fairpoint/maintenance/arrivals)
 "qGj" = (
 /obj/structure/table/woodentable,
 /obj/item/modular_computer/laptop/preset/records,
@@ -16020,8 +15648,6 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled,
 /area/fairpoint/crew_quarters/sleep/cryo)
-"qMJ" = (
-/area/fairpoint/street/outskirts)
 "qMN" = (
 /obj/machinery/camera/network/research{
 	c_tag = "SCI - Research Auxiliary Access";
@@ -16600,11 +16226,9 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/sleeper)
 "rts" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
+/obj/effect/floor_decal/spline/fancy/wood,
+/turf/simulated/floor/wood/ebony,
+/area/fairpoint/street/north)
 "rtt" = (
 /obj/machinery/power/apc/hyper{
 	dir = 8
@@ -16704,13 +16328,6 @@
 "rxV" = (
 /turf/simulated/wall/iron,
 /area/turbolift/sewer_exit)
-"rxZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "rya" = (
 /obj/machinery/door/airlock/glass/security,
 /turf/simulated/floor/tiled/monotile,
@@ -16750,10 +16367,6 @@
 /obj/structure/table/woodentable,
 /turf/simulated/floor/lino,
 /area/fairpoint/police/detectives_office)
-"rAU" = (
-/obj/structure/sign/warning,
-/turf/simulated/wall/wood,
-/area/fairpoint/street/east)
 "rBr" = (
 /obj/machinery/door/airlock/command{
 	name = "Record Room"
@@ -17109,10 +16722,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/fairpoint/medical/psych)
-"rVZ" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/fairpoint/maintenance/arrivals)
 "rWn" = (
 /obj/structure/window/reinforced{
 	health = 1e+006
@@ -17685,7 +17294,6 @@
 /obj/structure/flora/pottedplant/large{
 	pixel_y = 15
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/crew_quarters/bar)
 "sEM" = (
@@ -17837,11 +17445,6 @@
 /obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/turret_protected/ai_server_room)
-"sJp" = (
-/obj/structure/catwalk,
-/obj/machinery/door/airlock/hatch/maintenance,
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "sJx" = (
 /obj/structure/bed/sofa{
 	dir = 8
@@ -17959,12 +17562,6 @@
 /obj/machinery/vending/cigarette,
 /turf/simulated/floor/wood/usedup,
 /area/fairpoint/street/east)
-"sPk" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/simulated/wall/iron,
-/area/fairpoint/maintenance/arrivals)
 "sPG" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
@@ -18024,12 +17621,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/street/east)
-"sSY" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "sTf" = (
 /obj/effect/floor_decal/corner/grey{
 	tag = "icon-corner_white (NORTHEAST)";
@@ -18078,11 +17669,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/fairpoint/police/brig/interrogation)
 "sVj" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
 /obj/structure/table/reinforced,
 /obj/item/clothing/accessory/armor/helmcover/blue,
 /obj/item/clothing/accessory/armor/helmcover/blue,
@@ -18164,10 +17750,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/fairpoint/crew_quarters/bar)
-"sXW" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced,
-/area/fairpoint/police/cop)
 "sYX" = (
 /obj/machinery/recharger/wallcharger,
 /turf/simulated/wall/concrete{
@@ -18913,7 +18495,6 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
-/obj/effect/wingrille_spawn/reinforced_borosilicate,
 /turf/simulated/floor,
 /area/fairpoint/turret_protected/ai_server_room)
 "tMb" = (
@@ -19055,10 +18636,6 @@
 /obj/structure/table/reinforced,
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/police/detectives_office)
-"tVI" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/dark,
-/area/fairpoint/cityhall)
 "tWn" = (
 /obj/structure/table/woodentable,
 /obj/structure/window/reinforced{
@@ -19366,12 +18943,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/turret_protected/ai_server_room)
-"umy" = (
-/obj/structure/stairs{
-	dir = 8
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "umS" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/simulated/floor/tiled/techfloor,
@@ -19710,15 +19281,6 @@
 /obj/structure/bed/chair/office/comfy/beige,
 /turf/simulated/floor/carpet,
 /area/fairpoint/cityhall/meeting_room)
-"uFQ" = (
-/obj/structure/stairs{
-	dir = 1
-	},
-/obj/effect/floor_decal/spline/fancy/wood{
-	dir = 6
-	},
-/turf/simulated/floor/wood/walnut,
-/area/fairpoint/street/north)
 "uGg" = (
 /obj/random/trash,
 /obj/effect/decal/cleanable/dirt,
@@ -19727,11 +19289,6 @@
 "uGj" = (
 /obj/machinery/light/small{
 	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/prison/dorm)
@@ -19953,7 +19510,6 @@
 	name = "ATM";
 	pixel_x = 32
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/crew_quarters/bar)
 "uVA" = (
@@ -20286,12 +19842,6 @@
 /obj/machinery/light/neon/purple,
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/crew_quarters/bar)
-"vrX" = (
-/obj/turbolift_map_holder/fairpoint{
-	dir = 4
-	},
-/turf/space,
-/area/fairpoint/street/east)
 "vsh" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
@@ -20329,7 +19879,6 @@
 /area/fairpoint/police/detectives_office)
 "vuo" = (
 /obj/machinery/vending/snack,
-/obj/structure/catwalk,
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/cityhall)
 "vuB" = (
@@ -21009,11 +20558,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/patient_a)
-"wjy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/exterior/open,
-/area/fairpoint/street)
 "wjK" = (
 /obj/structure/closet/secure_closet/security,
 /obj/effect/floor_decal/corner/paleblue/full{
@@ -21236,14 +20780,6 @@
 	},
 /turf/simulated/floor/tiled/old_tile,
 /area/fairpoint/street/east)
-"wwh" = (
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "north bump";
-	pixel_y = 24
-	},
-/turf/simulated/floor/tiled/white,
-/area/fairpoint/police/detectives_office)
 "wwt" = (
 /obj/machinery/telecomms/allinone,
 /turf/simulated/floor/tiled/techfloor,
@@ -21270,15 +20806,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/shipping/office)
-"wxH" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
-/obj/structure/filingcabinet,
-/turf/simulated/floor/tiled/techfloor,
-/area/fairpoint/police/warden)
 "wyh" = (
 /obj/machinery/door/window/brigdoor{
 	name = "police moped door"
@@ -21546,8 +21073,7 @@
 "wHk" = (
 /obj/machinery/holosign/surgery,
 /obj/machinery/door/airlock/medical{
-	name = "Operating Theatre 1";
-	req_access = list(45)
+	name = "Operating Theatre 1"
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/surgery)
@@ -22257,13 +21783,6 @@
 	},
 /turf/simulated/floor/grass,
 /area/fairpoint/cityhall)
-"xsf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "xsi" = (
 /obj/effect/floor_decal/corner/pink{
 	tag = "icon-corner_white (NORTHWEST)";
@@ -22313,16 +21832,6 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
-"xvc" = (
-/obj/effect/wallframe_spawn/reinforced/bare,
-/obj/machinery/atmospherics/pipe/zpipe/up/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
-	dir = 4
-	},
-/turf/simulated/floor,
-/area/fairpoint/shipping/storage)
 "xvf" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/ore_box,
@@ -22536,10 +22045,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/street/east)
-"xHA" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/tiled/techmaint,
-/area/fairpoint/maintenance/arrivals)
 "xHG" = (
 /obj/machinery/vending/coffee{
 	dir = 8
@@ -22767,7 +22272,6 @@
 	icon_state = "shutter0";
 	name = "Defense Shutters"
 	},
-/obj/structure/grille,
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled,
 /area/fairpoint/law/lawoffice)
@@ -22961,13 +22465,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/shipping/miningdock)
-"ycI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 2;
-	icon_state = "pipe-c"
-	},
-/turf/exterior/water/chlorine,
-/area/fairpoint/maintenance/arrivals)
 "ycY" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
@@ -27828,93 +27325,93 @@ jbX
 fwu
 jbX
 nhE
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
 gWr
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
 cNR
 wFf
 ksj
@@ -27934,30 +27431,30 @@ tlj
 ksj
 geg
 cNR
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
-qFn
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
+gWr
 nhE
 jbX
 fwu
@@ -30567,8 +30064,8 @@ dpT
 dpT
 dpT
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -30726,8 +30223,8 @@ dpT
 wYe
 wYe
 wYe
-qnt
-qnt
+wYe
+wYe
 wYe
 wYe
 wYe
@@ -30872,9 +30369,9 @@ dpT
 dpT
 dpT
 dpT
-nVT
 dpT
-nVT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -30885,8 +30382,8 @@ dpT
 wYe
 wYe
 wYe
-qnt
-qnt
+wYe
+wYe
 wYe
 wYe
 wYe
@@ -31016,10 +30513,10 @@ dpT
 dpT
 dpT
 dpT
-qkS
-qkS
-qkS
-qkS
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -31179,19 +30676,19 @@ dpT
 dpT
 dpT
 dpT
-owf
-dpT
-nVT
-nVT
 dpT
 dpT
 dpT
 dpT
-nVT
 dpT
 dpT
 dpT
-nVT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -31338,17 +30835,17 @@ dpT
 dpT
 dpT
 dpT
-owf
-dpT
-dpT
-nVT
 dpT
 dpT
 dpT
-nVT
 dpT
 dpT
-nVT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -31497,7 +30994,7 @@ dpT
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -31656,14 +31153,14 @@ dpT
 dpT
 dpT
 dpT
-owf
 dpT
 dpT
 dpT
 dpT
 dpT
 dpT
-nVT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -31815,11 +31312,11 @@ dpT
 dpT
 dpT
 dpT
-owf
 dpT
 dpT
 dpT
-nVT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -31974,11 +31471,6 @@ dpT
 dpT
 dpT
 dpT
-owf
-dpT
-dpT
-dpT
-nVT
 dpT
 dpT
 dpT
@@ -31988,7 +31480,12 @@ dpT
 dpT
 dpT
 dpT
-nVT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -32133,7 +31630,7 @@ dpT
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -32283,15 +31780,15 @@ bIo
 bIo
 dpT
 dpT
-cDP
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 wGe
 dpT
 dpT
@@ -32442,7 +31939,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 bIo
@@ -32471,16 +31968,16 @@ bIo
 bIo
 bIo
 bIo
-xHA
-jdO
+bIo
 jYE
 jYE
 jYE
 jYE
 jYE
 jYE
-jdO
-xHA
+jYE
+jYE
+bIo
 bIo
 bIo
 dpT
@@ -32601,7 +32098,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 bIo
@@ -32630,16 +32127,16 @@ bIo
 bIo
 bIo
 bIo
-xHA
-jdO
+bIo
 jYE
 jYE
 jYE
 jYE
 jYE
 jYE
-jdO
-xHA
+jYE
+jYE
+bIo
 bIo
 bIo
 dpT
@@ -32760,7 +32257,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -32919,7 +32416,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -33078,7 +32575,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -33237,7 +32734,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -33396,7 +32893,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -33404,55 +32901,55 @@ aLC
 aLC
 aLC
 aLC
-aJw
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-qkS
-pdB
-pdB
-qkS
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-pdB
-pdB
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-pdB
-pdB
-nRs
-nRs
-nRs
-nRs
-nRs
-xsf
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+dpT
+jYE
+jYE
+dpT
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+jYE
+jYE
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+jYE
+jYE
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
 aLC
 aLC
 aLC
@@ -33555,7 +33052,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -33563,7 +33060,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -33611,7 +33108,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -33714,7 +33211,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -33722,7 +33219,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jbX
 jbX
@@ -33770,7 +33267,7 @@ dpT
 dpT
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 dpT
@@ -33873,7 +33370,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -33881,7 +33378,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 bIo
 bIo
@@ -33929,36 +33426,36 @@ dpT
 dpT
 aLC
 aLC
-ycI
-nRs
-nRs
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-dPA
-deP
+aLC
+aLC
+aLC
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+bIo
+bIo
 bIo
 bIo
 bIo
@@ -34032,7 +33529,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -34040,7 +33537,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -34117,7 +33614,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 bIo
 bIo
@@ -34191,7 +33688,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -34199,7 +33696,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -34276,7 +33773,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 dpT
@@ -34350,7 +33847,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -34358,7 +33855,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -34435,7 +33932,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -34509,7 +34006,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -34517,7 +34014,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -34594,7 +34091,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -34668,7 +34165,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -34676,7 +34173,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -34753,7 +34250,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -34827,7 +34324,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -34835,7 +34332,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -34912,7 +34409,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -34986,7 +34483,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -34994,7 +34491,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -35071,7 +34568,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -35145,7 +34642,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -35153,7 +34650,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -35230,7 +34727,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -35304,7 +34801,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -35312,7 +34809,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -35389,7 +34886,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -35463,7 +34960,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -35471,7 +34968,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -35548,7 +35045,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -35622,7 +35119,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -35630,7 +35127,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -35707,7 +35204,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -35781,7 +35278,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -35789,7 +35286,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -35866,7 +35363,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -35940,7 +35437,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -35948,7 +35445,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -36025,7 +35522,7 @@ aLC
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -36099,7 +35596,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -36107,7 +35604,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -36184,7 +35681,7 @@ aLC
 aLC
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -36258,7 +35755,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -36266,7 +35763,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -36343,7 +35840,7 @@ aLC
 aLC
 aLC
 jYE
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -36417,58 +35914,58 @@ bIo
 bIo
 dpT
 dpT
-owf
-bIo
-bIo
-dpT
-aLC
-aLC
-aLC
-aLC
-hJr
-jbX
-jYE
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
 dpT
 bIo
 bIo
 dpT
+aLC
+aLC
+aLC
+aLC
+aLC
+jbX
+jYE
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+bIo
+bIo
+dpT
 dpT
 dpT
 dpT
@@ -36502,7 +35999,7 @@ jYE
 jYE
 jYE
 jYE
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -36576,58 +36073,58 @@ bIo
 bIo
 dpT
 dpT
-owf
-bIo
-bIo
-dpT
-aLC
-aLC
-aLC
-aLC
-hJr
-jbX
-jYE
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
 dpT
 bIo
 bIo
 dpT
+aLC
+aLC
+aLC
+aLC
+aLC
+jbX
+jYE
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+bIo
+bIo
+dpT
 dpT
 dpT
 dpT
@@ -36661,7 +36158,7 @@ jYE
 jYE
 jYE
 jYE
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -36735,58 +36232,58 @@ bIo
 bIo
 dpT
 dpT
-owf
-bIo
-bIo
-dpT
-aLC
-aLC
-aLC
-aLC
-hJr
-jbX
-jYE
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
-dpT
 dpT
 bIo
 bIo
 dpT
+aLC
+aLC
+aLC
+aLC
+aLC
+jbX
+jYE
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+bIo
+bIo
+dpT
 dpT
 dpT
 dpT
@@ -36820,7 +36317,7 @@ jYE
 jYE
 jYE
 jYE
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -36894,7 +36391,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -36902,7 +36399,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -36979,7 +36476,7 @@ aLC
 aLC
 aLC
 jYE
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -37053,7 +36550,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -37061,7 +36558,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -37138,7 +36635,7 @@ aLC
 aLC
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -37212,7 +36709,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -37220,7 +36717,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -37297,7 +36794,7 @@ aLC
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -37371,7 +36868,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -37379,7 +36876,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -37456,7 +36953,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -37530,7 +37027,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -37538,7 +37035,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -37615,7 +37112,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -37689,7 +37186,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -37697,7 +37194,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -37774,7 +37271,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -37848,7 +37345,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -37856,7 +37353,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -37933,7 +37430,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -38007,7 +37504,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -38015,7 +37512,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -38092,7 +37589,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -38166,7 +37663,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -38174,7 +37671,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -38251,7 +37748,7 @@ dpT
 dpT
 dpT
 bIo
-gFy
+bIo
 bIo
 dpT
 bCU
@@ -38325,7 +37822,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -38333,7 +37830,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -38410,7 +37907,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -38484,7 +37981,7 @@ bIo
 bIo
 dpT
 dpT
-owf
+dpT
 bIo
 bIo
 dpT
@@ -38492,7 +37989,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -38569,7 +38066,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 bCU
@@ -38643,7 +38140,7 @@ bIo
 hun
 dpT
 dpT
-owf
+dpT
 oBv
 bIo
 dpT
@@ -38651,7 +38148,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -38728,7 +38225,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -38802,7 +38299,7 @@ bIo
 hun
 dpT
 dpT
-owf
+dpT
 oBv
 bIo
 dpT
@@ -38810,7 +38307,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -38887,7 +38384,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -38962,14 +38459,14 @@ hun
 oUg
 bIo
 dbp
-dSC
-dPA
-qkS
-nRs
-nRs
-nRs
-nRs
-aan
+oBv
+bIo
+dpT
+aLC
+aLC
+aLC
+aLC
+aLC
 jbX
 jYE
 dpT
@@ -39046,7 +38543,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -39128,7 +38625,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -39205,7 +38702,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -39287,7 +38784,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -39364,7 +38861,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -39446,7 +38943,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -39523,7 +39020,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -39605,7 +39102,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -39682,7 +39179,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -39764,7 +39261,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -39841,7 +39338,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -39923,7 +39420,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -40000,7 +39497,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -40082,7 +39579,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -40159,7 +39656,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -40241,7 +39738,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -40318,7 +39815,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -40400,7 +39897,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -40477,7 +39974,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -40559,7 +40056,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -40636,7 +40133,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -40718,7 +40215,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -40795,7 +40292,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -40877,7 +40374,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -40954,7 +40451,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -41036,7 +40533,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -41113,7 +40610,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -41195,7 +40692,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -41272,7 +40769,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 lPR
@@ -41342,8 +40839,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-jml
+bIo
+hun
 dpT
 dpT
 dpT
@@ -41354,7 +40851,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -41431,7 +40928,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 oTt
@@ -41501,8 +40998,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-jml
+bIo
+hun
 oUg
 bIo
 oUg
@@ -41513,7 +41010,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -41590,7 +41087,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 oTt
@@ -41660,8 +41157,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-jml
+bIo
+hun
 dpT
 dpT
 dpT
@@ -41672,7 +41169,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -41749,7 +41246,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 oTt
@@ -41819,8 +41316,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-jml
+bIo
+hun
 dpT
 dpT
 dpT
@@ -41831,7 +41328,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -41908,7 +41405,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 oTt
@@ -41978,8 +41475,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -41990,7 +41487,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -42067,7 +41564,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 dpT
 dpT
@@ -42137,19 +41634,19 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
-dPA
-dPA
-qkS
-nRs
-nRs
-nRs
-nRs
-beM
+bIo
+bIo
+dpT
+aLC
+aLC
+aLC
+aLC
+aLC
 jbX
 jYE
 dpT
@@ -42226,7 +41723,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 bIo
 bIo
@@ -42296,8 +41793,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -42308,7 +41805,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jYE
 dpT
@@ -42385,7 +41882,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 bIo
 bIo
@@ -42455,8 +41952,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -42467,7 +41964,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 bIo
 bIo
@@ -42544,7 +42041,7 @@ dpT
 dpT
 dpT
 pfl
-eVz
+pfl
 dpT
 dpT
 dpT
@@ -42614,8 +42111,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -42626,7 +42123,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 jbX
 jbX
 jbX
@@ -42703,7 +42200,7 @@ aLC
 aLC
 aLC
 jYE
-lAN
+jYE
 aLC
 aLC
 aLC
@@ -42773,8 +42270,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -42785,60 +42282,60 @@ aLC
 aLC
 aLC
 aLC
-ycI
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-nRs
-xsf
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
+aLC
 aLC
 aLC
 aLC
@@ -42862,7 +42359,7 @@ aLC
 aLC
 aLC
 jYE
-lAN
+jYE
 aLC
 aLC
 aLC
@@ -42932,8 +42429,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -42997,7 +42494,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -43021,7 +42518,7 @@ aLC
 aLC
 aLC
 jYE
-lAN
+jYE
 aLC
 aLC
 aLC
@@ -43091,8 +42588,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -43156,7 +42653,7 @@ aLC
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -43180,7 +42677,7 @@ aLC
 aLC
 aLC
 jYE
-lAN
+jYE
 aLC
 aLC
 aLC
@@ -43250,8 +42747,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -43315,7 +42812,7 @@ aLC
 aLC
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -43339,7 +42836,7 @@ dpT
 dpT
 aLC
 jYE
-lAN
+jYE
 aLC
 aLC
 aLC
@@ -43409,8 +42906,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -43474,7 +42971,7 @@ aLC
 aLC
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -43498,7 +42995,7 @@ dpT
 dpT
 dpT
 pax
-dCi
+pax
 dpT
 dpT
 dpT
@@ -43568,8 +43065,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -43633,7 +43130,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -43657,7 +43154,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -43727,8 +43224,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -43792,7 +43289,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -43816,7 +43313,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -43886,8 +43383,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -43951,7 +43448,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -43975,7 +43472,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -44045,8 +43542,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -44110,7 +43607,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -44134,7 +43631,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -44204,8 +43701,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -44269,7 +43766,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -44293,7 +43790,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -44363,8 +43860,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -44428,7 +43925,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -44452,7 +43949,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -44522,8 +44019,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-rVZ
+bIo
+jbX
 dpT
 dpT
 aLC
@@ -44587,7 +44084,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -44611,7 +44108,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -44681,8 +44178,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-rVZ
+bIo
+jbX
 jbX
 jYE
 jYE
@@ -44746,7 +44243,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -44770,7 +44267,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 bIo
 bIo
@@ -44840,8 +44337,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-rVZ
+bIo
+jbX
 jbX
 jYE
 jYE
@@ -44905,7 +44402,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -44929,7 +44426,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 bIo
 bIo
 bIo
@@ -44999,8 +44496,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-rVZ
+bIo
+jbX
 dpT
 dpT
 aLC
@@ -45064,7 +44561,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -45088,7 +44585,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -45158,8 +44655,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -45223,7 +44720,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -45247,7 +44744,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -45317,8 +44814,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -45382,7 +44879,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -45406,7 +44903,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -45476,8 +44973,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -45541,7 +45038,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -45565,7 +45062,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -45635,8 +45132,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -45700,7 +45197,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -45724,7 +45221,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -45794,8 +45291,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -45859,7 +45356,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -45883,7 +45380,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -45953,8 +45450,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -46018,7 +45515,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -46042,7 +45539,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -46112,8 +45609,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -46177,7 +45674,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -46201,7 +45698,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -46271,8 +45768,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -46336,7 +45833,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -46360,7 +45857,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -46430,23 +45927,6 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
-dpT
-dpT
-aLC
-aLC
-aLC
-aLC
-aLC
-aLC
-dpT
-dpT
-bIo
-bIo
-bIo
-bIo
-bIo
 bIo
 bIo
 dpT
@@ -46454,6 +45934,23 @@ dpT
 aLC
 aLC
 aLC
+aLC
+aLC
+aLC
+dpT
+dpT
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+dpT
+dpT
+aLC
+aLC
+aLC
 dpT
 dpT
 dpT
@@ -46495,7 +45992,7 @@ aLC
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -46519,7 +46016,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -46589,8 +46086,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 aLC
@@ -46654,13 +46151,13 @@ aLC
 dpT
 dpT
 dpT
-rxZ
 dpT
 dpT
 dpT
 dpT
 dpT
-qkS
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -46678,7 +46175,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -46748,8 +46245,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -46826,18 +46323,18 @@ dpT
 dpT
 dpT
 dpT
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
-qkS
 dpT
 dpT
-qkS
-dPA
-sSY
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -46907,8 +46404,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -46996,7 +46493,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -47066,8 +46563,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -47155,7 +46652,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -47225,8 +46722,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -47314,7 +46811,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -47384,8 +46881,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -47473,7 +46970,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -47543,8 +47040,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -47632,7 +47129,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -47702,8 +47199,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -47791,7 +47288,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -47861,8 +47358,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -47950,7 +47447,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -48020,8 +47517,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -48109,7 +47606,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -48179,8 +47676,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -48268,7 +47765,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -48338,8 +47835,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -48427,7 +47924,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -48497,8 +47994,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -48586,7 +48083,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -48656,8 +48153,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -48745,7 +48242,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -48815,8 +48312,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -48904,7 +48401,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -48974,8 +48471,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -49063,7 +48560,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -49133,8 +48630,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -49222,7 +48719,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -49292,8 +48789,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -49381,7 +48878,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -49451,8 +48948,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -49540,7 +49037,7 @@ dpT
 dpT
 dpT
 bIo
-bsQ
+bIo
 dpT
 dpT
 dpT
@@ -49610,8 +49107,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -49699,13 +49196,13 @@ dpT
 dpT
 dpT
 bIo
-kLk
-qkS
-qkS
-qkS
-rts
-qkS
-sPk
+bIo
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -49769,8 +49266,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -49862,7 +49359,7 @@ jYE
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -49928,8 +49425,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 etW
@@ -50021,7 +49518,7 @@ jYE
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -50087,8 +49584,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -50180,7 +49677,7 @@ jYE
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -50246,8 +49743,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -50339,7 +49836,7 @@ jYE
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -50405,8 +49902,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -50498,7 +49995,7 @@ jYE
 aLC
 aLC
 aLC
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -50564,8 +50061,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -50657,7 +50154,7 @@ jYE
 dpT
 dpT
 dpT
-hJr
+aLC
 aLC
 aLC
 aLC
@@ -50723,8 +50220,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -50816,7 +50313,7 @@ bIo
 dpT
 dpT
 dpT
-hJr
+aLC
 aLC
 aLC
 dpT
@@ -50882,8 +50379,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -50975,7 +50472,7 @@ bIo
 dpT
 dpT
 dpT
-hJr
+aLC
 aLC
 aLC
 dpT
@@ -51041,8 +50538,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -51134,7 +50631,7 @@ bIo
 dpT
 dpT
 dpT
-hJr
+aLC
 aLC
 dpT
 dpT
@@ -51200,8 +50697,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -51293,7 +50790,7 @@ bIo
 bIo
 bIo
 jYE
-lAN
+jYE
 jYE
 jYE
 jYE
@@ -51359,8 +50856,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -51452,7 +50949,7 @@ bIo
 bIo
 bIo
 jYE
-lAN
+jYE
 jYE
 jYE
 jYE
@@ -51518,8 +51015,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -51611,7 +51108,7 @@ bIo
 dpT
 dpT
 dpT
-hJr
+aLC
 aLC
 aLC
 dpT
@@ -51677,8 +51174,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -51770,7 +51267,7 @@ bIo
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -51836,8 +51333,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -51929,7 +51426,7 @@ bIo
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -51995,8 +51492,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -52088,7 +51585,7 @@ bIo
 dpT
 dpT
 dpT
-owf
+dpT
 dpT
 dpT
 dpT
@@ -52154,8 +51651,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -52212,9 +51709,9 @@ bIo
 dpT
 dpT
 dpT
-nVT
 dpT
-nVT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -52313,8 +51810,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -52370,20 +51867,20 @@ bIo
 bIo
 dpT
 dpT
-nVT
-nVT
 dpT
 dpT
 dpT
 dpT
 dpT
-nVT
 dpT
 dpT
 dpT
 dpT
 dpT
-nVT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -52472,8 +51969,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -52530,7 +52027,6 @@ bIo
 dpT
 dpT
 dpT
-nVT
 dpT
 dpT
 dpT
@@ -52540,20 +52036,21 @@ dpT
 dpT
 dpT
 dpT
-nVT
-dpT
-nVT
 dpT
 dpT
 dpT
 dpT
 dpT
-nVT
-nVT
-nVT
-nVT
-nVT
-nVT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -52631,8 +52128,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -52701,18 +52198,6 @@ dpT
 dpT
 dpT
 dpT
-nVT
-dpT
-dpT
-dpT
-dpT
-dpT
-nVT
-nVT
-nVT
-nVT
-nVT
-nVT
 dpT
 dpT
 dpT
@@ -52722,8 +52207,20 @@ dpT
 dpT
 dpT
 dpT
-qkS
-qkS
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -52790,8 +52287,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -52845,12 +52342,6 @@ dpT
 dpT
 bIo
 fQx
-nVT
-nVT
-nVT
-nVT
-dpT
-nVT
 dpT
 dpT
 dpT
@@ -52860,18 +52351,24 @@ dpT
 dpT
 dpT
 dpT
-nVT
 dpT
 dpT
 dpT
 dpT
 dpT
-nVT
-nVT
-nVT
-nVT
-nVT
-nVT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -52949,8 +52446,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -53004,33 +52501,33 @@ dpT
 dpT
 bIo
 cOG
-nVT
-nVT
-nVT
-nVT
-dpT
-nVT
-dpT
-dpT
-nVT
-nVT
-nVT
-dpT
-nVT
-dpT
-dpT
-nVT
 dpT
 dpT
 dpT
 dpT
 dpT
-nVT
-nVT
-nVT
-nVT
-nVT
-nVT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -53108,8 +52605,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 oUg
 bIo
 bIo
@@ -53172,24 +52669,24 @@ dpT
 dpT
 dpT
 dpT
-nVT
-nVT
-dpT
-dpT
-dpT
-dpT
-nVT
 dpT
 dpT
 dpT
 dpT
 dpT
-nVT
-nVT
-nVT
-nVT
-nVT
-nVT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
+dpT
 dpT
 dpT
 dpT
@@ -53267,8 +52764,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 oUg
 bIo
 bIo
@@ -53426,8 +52923,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -53585,8 +53082,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -53744,8 +53241,8 @@ wEt
 wEt
 ylv
 dpT
-xHA
-xHA
+bIo
+bIo
 dpT
 dpT
 dpT
@@ -53905,36 +53402,7 @@ ylv
 dpT
 bIo
 bIo
-sJp
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
+oUg
 bIo
 bIo
 bIo
@@ -53946,19 +53414,48 @@ bIo
 bIo
 bIo
 bIo
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
 itC
 itC
 idV
 bIo
 bIo
 cOG
-aOE
+dpT
 dpT
 dpT
 dpT
@@ -54064,52 +53561,52 @@ ylv
 dpT
 bIo
 bIo
-sJp
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
-xHA
+oUg
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
+bIo
 cyz
 itC
 itC
@@ -60389,7 +59886,7 @@ mYS
 cMw
 cMw
 dXB
-cJx
+rps
 rhj
 rhj
 rps
@@ -64754,8 +64251,8 @@ cgn
 oru
 nPX
 buU
-tVI
-tVI
+efg
+efg
 uVQ
 xrN
 tib
@@ -64913,14 +64410,14 @@ kph
 oiS
 kph
 buU
-tVI
-tVI
-tVI
 efg
 efg
-tVI
-tVI
-tVI
+efg
+efg
+efg
+efg
+efg
+efg
 nyg
 rLx
 rLr
@@ -65238,7 +64735,7 @@ efg
 efg
 efg
 efg
-tVI
+efg
 puq
 spO
 nyg
@@ -65390,14 +64887,14 @@ kph
 kph
 hCG
 hwS
-tVI
-tVI
-tVI
-tVI
-tVI
-tVI
 efg
-tVI
+efg
+efg
+efg
+efg
+efg
+efg
+efg
 nyg
 rLr
 rLr
@@ -69551,7 +69048,7 @@ aDQ
 aDQ
 kiD
 bFB
-ojh
+mpt
 arB
 aWw
 jMW
@@ -69823,7 +69320,7 @@ hdD
 lqs
 ncP
 qsa
-aTy
+szv
 aTy
 aTy
 szv
@@ -69982,7 +69479,7 @@ gUA
 lqs
 ncP
 qsa
-aTy
+szv
 aTy
 aTy
 szv
@@ -70664,7 +70161,7 @@ aDQ
 aDQ
 kiD
 bFB
-erR
+bnp
 mku
 mku
 mku
@@ -70823,7 +70320,7 @@ aDQ
 aDQ
 kiD
 bFB
-erR
+bnp
 dks
 xCK
 xCK
@@ -70982,7 +70479,7 @@ aDQ
 aDQ
 kiD
 bFB
-qzb
+emQ
 mku
 ssV
 ssV
@@ -71141,7 +70638,7 @@ aDQ
 aDQ
 kiD
 bFB
-qzb
+emQ
 nGs
 nBq
 nBq
@@ -71890,7 +71387,7 @@ dcj
 rsF
 ncP
 qsa
-aTy
+szv
 aTy
 aTy
 szv
@@ -72049,7 +71546,7 @@ rsF
 rsF
 ncP
 wyh
-aTy
+szv
 aTy
 aTy
 szv
@@ -72207,7 +71704,7 @@ ncP
 ncP
 ncP
 ncP
-szv
+qsa
 szv
 aTy
 aTy
@@ -74642,12 +74139,12 @@ wQP
 mmQ
 tPS
 deb
-iiM
-iiM
-iiM
+nZz
+nZz
+nZz
 sEh
-iiM
-iiM
+nZz
+nZz
 oGQ
 fCc
 bic
@@ -74965,7 +74462,7 @@ oBR
 nZz
 oBR
 oBR
-iiM
+nZz
 oGQ
 nHC
 nHC
@@ -75119,12 +74616,12 @@ wQP
 mmQ
 tPS
 jyH
-iiM
-iiM
+nZz
+nZz
 uUq
 sEh
 oBR
-iiM
+nZz
 oGQ
 oGQ
 oGQ
@@ -75281,12 +74778,12 @@ jyH
 jyH
 jyH
 jyH
-iiM
+nZz
 oBR
-iiM
-iiM
-iiM
-iiM
+nZz
+nZz
+nZz
+nZz
 jyH
 bih
 bih
@@ -75303,12 +74800,12 @@ wNm
 qeb
 mON
 oxn
+neb
+neb
+neb
 hoL
-hoL
-hoL
-hoL
-vrX
 dWk
+neb
 gLK
 oxn
 neb
@@ -75462,12 +74959,12 @@ wNm
 qeb
 mON
 oxn
-hoL
-hoL
-hoL
-hoL
-hoL
+neb
+neb
+neb
+neb
 dWk
+neb
 mgJ
 fLA
 neb
@@ -75602,9 +75099,9 @@ rYq
 rYq
 rYq
 jyH
-iiM
-iiM
-iiM
+nZz
+nZz
+nZz
 jyH
 bih
 nZz
@@ -75621,12 +75118,12 @@ wNm
 qeb
 mON
 oxn
-hoL
-hoL
-hoL
-hoL
-hoL
+neb
+neb
+neb
+neb
 dWk
+neb
 kbf
 oxn
 neb
@@ -75780,12 +75277,12 @@ wNm
 qeb
 mON
 oxn
-hoL
-hoL
-hoL
-hoL
-hoL
+neb
+neb
+neb
+neb
 dWk
+neb
 neb
 oxn
 oxn
@@ -75939,12 +75436,12 @@ wNm
 qeb
 mON
 oxn
-hoL
-hoL
-hoL
-hoL
-hoL
+oxn
+neb
+neb
+oxn
 dWk
+neb
 trt
 oxn
 neb
@@ -76097,12 +75594,12 @@ mON
 wNm
 qeb
 mON
-rAU
+oxn
 yfv
 uBV
 uBV
-uBV
 yfv
+neb
 neb
 lSA
 fLA
@@ -78423,7 +77920,7 @@ syd
 oyq
 lvm
 oEN
-lAq
+nka
 oCX
 olu
 olu
@@ -81354,7 +80851,7 @@ wNm
 wNm
 ptG
 ptG
-lJa
+wGV
 wGV
 ptG
 ptG
@@ -83418,7 +82915,7 @@ fZQ
 fZQ
 ayW
 ayW
-xvc
+hNI
 ayW
 ayW
 dAu
@@ -84293,8 +83790,8 @@ iNT
 iNT
 iNT
 iNT
-umy
-umy
+cDj
+cDj
 wcW
 iNg
 rIu
@@ -84442,7 +83939,7 @@ jUB
 jUB
 jUB
 bvi
-fdH
+cDj
 cDj
 iNT
 iNT
@@ -84600,8 +84097,8 @@ wcW
 jUB
 jUB
 jUB
-jUB
-aYT
+rts
+cDj
 qnD
 dEO
 dEO
@@ -84759,8 +84256,8 @@ wcW
 cwI
 jUB
 jUB
-jUB
-uFQ
+rts
+cDj
 gEr
 jan
 jan
@@ -84919,7 +84416,7 @@ jUB
 jUB
 jUB
 bvi
-neJ
+cDj
 cDj
 iNT
 iNT
@@ -86951,7 +86448,7 @@ elf
 elf
 elf
 vvE
-qMJ
+vvE
 "}
 (2,1,3) = {"
 fGj
@@ -87110,7 +86607,7 @@ elf
 elf
 elf
 vvE
-qMJ
+vvE
 "}
 (3,1,3) = {"
 fGj
@@ -87269,7 +86766,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (4,1,3) = {"
 fGj
@@ -87428,7 +86925,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (5,1,3) = {"
 fGj
@@ -87587,7 +87084,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (6,1,3) = {"
 fGj
@@ -87746,7 +87243,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (7,1,3) = {"
 fGj
@@ -87905,7 +87402,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (8,1,3) = {"
 fGj
@@ -88064,7 +87561,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (9,1,3) = {"
 fGj
@@ -88223,7 +87720,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (10,1,3) = {"
 fGj
@@ -88382,7 +87879,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (11,1,3) = {"
 fGj
@@ -88541,7 +88038,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (12,1,3) = {"
 fGj
@@ -88700,7 +88197,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (13,1,3) = {"
 fGj
@@ -88859,7 +88356,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (14,1,3) = {"
 fGj
@@ -89018,7 +88515,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (15,1,3) = {"
 fGj
@@ -89177,7 +88674,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (16,1,3) = {"
 fGj
@@ -89336,7 +88833,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (17,1,3) = {"
 fGj
@@ -89495,7 +88992,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (18,1,3) = {"
 fGj
@@ -89654,7 +89151,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (19,1,3) = {"
 fGj
@@ -89813,7 +89310,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (20,1,3) = {"
 fGj
@@ -89972,7 +89469,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (21,1,3) = {"
 fGj
@@ -90131,7 +89628,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (22,1,3) = {"
 fGj
@@ -90290,7 +89787,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (23,1,3) = {"
 fGj
@@ -90449,7 +89946,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (24,1,3) = {"
 fGj
@@ -90608,7 +90105,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (25,1,3) = {"
 fGj
@@ -90767,7 +90264,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (26,1,3) = {"
 fGj
@@ -90926,7 +90423,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (27,1,3) = {"
 fGj
@@ -91085,7 +90582,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (28,1,3) = {"
 fGj
@@ -91244,7 +90741,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (29,1,3) = {"
 fGj
@@ -91403,7 +90900,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (30,1,3) = {"
 fGj
@@ -91562,7 +91059,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (31,1,3) = {"
 fGj
@@ -91721,7 +91218,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (32,1,3) = {"
 fGj
@@ -91880,7 +91377,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (33,1,3) = {"
 fGj
@@ -92039,7 +91536,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (34,1,3) = {"
 fGj
@@ -92198,7 +91695,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (35,1,3) = {"
 fGj
@@ -92357,7 +91854,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (36,1,3) = {"
 fGj
@@ -92516,7 +92013,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (37,1,3) = {"
 fGj
@@ -92675,7 +92172,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (38,1,3) = {"
 fGj
@@ -92834,7 +92331,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (39,1,3) = {"
 fGj
@@ -92993,7 +92490,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (40,1,3) = {"
 fGj
@@ -93152,7 +92649,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (41,1,3) = {"
 fGj
@@ -93311,7 +92808,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (42,1,3) = {"
 fGj
@@ -93470,7 +92967,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (43,1,3) = {"
 fGj
@@ -93629,7 +93126,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (44,1,3) = {"
 fGj
@@ -93788,7 +93285,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (45,1,3) = {"
 fGj
@@ -93947,7 +93444,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (46,1,3) = {"
 fGj
@@ -94106,7 +93603,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (47,1,3) = {"
 fGj
@@ -94265,7 +93762,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (48,1,3) = {"
 fGj
@@ -94424,7 +93921,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (49,1,3) = {"
 fGj
@@ -94583,7 +94080,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (50,1,3) = {"
 fGj
@@ -94742,7 +94239,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (51,1,3) = {"
 fGj
@@ -94901,7 +94398,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (52,1,3) = {"
 fGj
@@ -95060,7 +94557,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (53,1,3) = {"
 fGj
@@ -95219,7 +94716,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (54,1,3) = {"
 fGj
@@ -95378,7 +94875,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (55,1,3) = {"
 fGj
@@ -95537,7 +95034,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (56,1,3) = {"
 fGj
@@ -95696,7 +95193,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (57,1,3) = {"
 fGj
@@ -95855,7 +95352,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (58,1,3) = {"
 fGj
@@ -95866,7 +95363,7 @@ bcr
 bWK
 hHt
 ozC
-sXW
+eiO
 hHt
 bWK
 gPh
@@ -96014,7 +95511,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (59,1,3) = {"
 fGj
@@ -96023,9 +95520,9 @@ fGj
 bcr
 bcr
 bWK
-cyw
+hHt
 eiO
-sXW
+eiO
 hHt
 bWK
 mzU
@@ -96173,7 +95670,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (60,1,3) = {"
 fGj
@@ -96332,7 +95829,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (61,1,3) = {"
 fGj
@@ -96342,7 +95839,7 @@ bcr
 bcr
 bWK
 kft
-sXW
+eiO
 eiO
 kft
 bWK
@@ -96491,7 +95988,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (62,1,3) = {"
 fGj
@@ -96501,8 +95998,8 @@ bcr
 bcr
 bWK
 kft
-sXW
-sXW
+eiO
+eiO
 kft
 bWK
 mzW
@@ -96650,7 +96147,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (63,1,3) = {"
 fGj
@@ -96661,7 +96158,7 @@ bcr
 bWK
 kft
 eiO
-sXW
+eiO
 kft
 hbK
 gaC
@@ -96809,7 +96306,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (64,1,3) = {"
 fGj
@@ -96818,7 +96315,7 @@ fGj
 bcr
 bcr
 dcE
-sXW
+eiO
 eiO
 eiO
 eiO
@@ -96968,7 +96465,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (65,1,3) = {"
 fGj
@@ -96978,7 +96475,7 @@ bcr
 bcr
 bWK
 eiO
-lRJ
+eiO
 eiO
 eiO
 qpN
@@ -97127,7 +96624,7 @@ fGj
 fGj
 fGj
 vvE
-qMJ
+vvE
 "}
 (66,1,3) = {"
 fGj
@@ -97286,7 +96783,7 @@ bcr
 bcr
 bcr
 vvE
-qMJ
+vvE
 "}
 (67,1,3) = {"
 fGj
@@ -97445,7 +96942,7 @@ bcr
 bcr
 fGj
 vvE
-qMJ
+vvE
 "}
 (68,1,3) = {"
 fGj
@@ -97485,7 +96982,7 @@ lzn
 eDI
 dXK
 dXK
-wwh
+tTN
 tTN
 tTN
 tTN
@@ -97781,7 +97278,7 @@ bcQ
 nbV
 kuw
 pSk
-htU
+pSk
 bWK
 toe
 toe
@@ -98598,7 +98095,7 @@ unk
 jLK
 rbg
 dXK
-igS
+kCN
 brS
 pYC
 tTN
@@ -99221,7 +98718,7 @@ kqI
 xoA
 mXe
 hwc
-nyJ
+ifO
 ifO
 ifO
 xXI
@@ -99512,7 +99009,7 @@ xrH
 xrH
 bxk
 vvE
-qMJ
+vvE
 "}
 (81,1,3) = {"
 fGj
@@ -99671,7 +99168,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (82,1,3) = {"
 fGj
@@ -99830,7 +99327,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (83,1,3) = {"
 fGj
@@ -99989,7 +99486,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (84,1,3) = {"
 fGj
@@ -100007,7 +99504,7 @@ ncP
 ncP
 qQV
 nFK
-kZv
+nFK
 nFK
 nFK
 nFK
@@ -100148,7 +99645,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (85,1,3) = {"
 fGj
@@ -100307,7 +99804,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (86,1,3) = {"
 fGj
@@ -100466,7 +99963,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (87,1,3) = {"
 fGj
@@ -100625,7 +100122,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (88,1,3) = {"
 fGj
@@ -100784,7 +100281,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (89,1,3) = {"
 fGj
@@ -100943,7 +100440,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (90,1,3) = {"
 fGj
@@ -101102,7 +100599,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (91,1,3) = {"
 fGj
@@ -101139,7 +100636,7 @@ ryf
 ryf
 ryf
 mxl
-ntF
+eHI
 sby
 baD
 glj
@@ -101261,7 +100758,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (92,1,3) = {"
 fGj
@@ -101420,7 +100917,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (93,1,3) = {"
 fGj
@@ -101579,7 +101076,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (94,1,3) = {"
 fGj
@@ -101738,7 +101235,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (95,1,3) = {"
 fGj
@@ -101897,7 +101394,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (96,1,3) = {"
 fGj
@@ -101929,7 +101426,7 @@ oQv
 iAc
 ePM
 ePM
-wxH
+aLE
 glj
 qTJ
 iSk
@@ -102056,7 +101553,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (97,1,3) = {"
 fGj
@@ -102067,7 +101564,7 @@ fGj
 nzP
 aGw
 ryC
-cTV
+wJg
 wJg
 wJg
 wJg
@@ -102215,7 +101712,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (98,1,3) = {"
 fGj
@@ -102374,7 +101871,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (99,1,3) = {"
 fGj
@@ -102533,7 +102030,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (100,1,3) = {"
 fGj
@@ -102692,7 +102189,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (101,1,3) = {"
 fGj
@@ -102704,7 +102201,7 @@ nzP
 lWz
 lWz
 njF
-loW
+tiN
 hfo
 qIL
 xLs
@@ -102851,7 +102348,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (102,1,3) = {"
 fGj
@@ -103010,7 +102507,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (103,1,3) = {"
 fGj
@@ -103169,7 +102666,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (104,1,3) = {"
 fGj
@@ -103203,7 +102700,7 @@ qPN
 kxB
 dQm
 glj
-lFh
+iSk
 iDU
 jbo
 iSk
@@ -103328,7 +102825,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (105,1,3) = {"
 fGj
@@ -103487,7 +102984,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (106,1,3) = {"
 fGj
@@ -103646,7 +103143,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (107,1,3) = {"
 fGj
@@ -103805,7 +103302,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (108,1,3) = {"
 fGj
@@ -103964,7 +103461,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (109,1,3) = {"
 fGj
@@ -104123,7 +103620,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (110,1,3) = {"
 fGj
@@ -104282,7 +103779,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (111,1,3) = {"
 fGj
@@ -104441,7 +103938,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (112,1,3) = {"
 fGj
@@ -104600,7 +104097,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (113,1,3) = {"
 fGj
@@ -104759,7 +104256,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (114,1,3) = {"
 fGj
@@ -104918,7 +104415,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (115,1,3) = {"
 fGj
@@ -105077,7 +104574,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (116,1,3) = {"
 fGj
@@ -105236,7 +104733,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (117,1,3) = {"
 fGj
@@ -105395,7 +104892,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (118,1,3) = {"
 fGj
@@ -105554,7 +105051,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (119,1,3) = {"
 fGj
@@ -105713,7 +105210,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (120,1,3) = {"
 fGj
@@ -105872,7 +105369,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (121,1,3) = {"
 fGj
@@ -106031,7 +105528,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (122,1,3) = {"
 fGj
@@ -106190,7 +105687,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (123,1,3) = {"
 fGj
@@ -106349,7 +105846,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (124,1,3) = {"
 bAB
@@ -106508,7 +106005,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (125,1,3) = {"
 bAB
@@ -106667,7 +106164,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (126,1,3) = {"
 bAB
@@ -106826,7 +106323,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (127,1,3) = {"
 bAB
@@ -106985,7 +106482,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (128,1,3) = {"
 bAB
@@ -107104,11 +106601,11 @@ bcr
 bcr
 xrH
 khm
-xrH
-xrH
-xrH
-xrH
-xrH
+erR
+erR
+erR
+erR
+khm
 khm
 sGf
 sGf
@@ -107144,7 +106641,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (129,1,3) = {"
 bAB
@@ -107263,11 +106760,11 @@ bcr
 bcr
 xrH
 khm
-xrH
-xrH
-xrH
-xrH
-xrH
+erR
+erR
+erR
+erR
+khm
 khm
 sGf
 sGf
@@ -107303,7 +106800,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (130,1,3) = {"
 bAB
@@ -107319,10 +106816,10 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
-pkY
-pkY
+bAB
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -107422,11 +106919,11 @@ bcr
 bcr
 xrH
 khm
-xrH
-xrH
-xrH
-xrH
-xrH
+erR
+erR
+erR
+erR
+khm
 khm
 sGf
 sGf
@@ -107462,7 +106959,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (131,1,3) = {"
 bAB
@@ -107480,7 +106977,7 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
 bAB
 bAB
 bAB
@@ -107581,11 +107078,11 @@ bcr
 bcr
 xrH
 khm
-xrH
-xrH
-xrH
-xrH
-xrH
+erR
+erR
+erR
+erR
+khm
 khm
 sGf
 sGf
@@ -107621,7 +107118,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (132,1,3) = {"
 bAB
@@ -107639,8 +107136,8 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -107740,11 +107237,11 @@ bcr
 bcr
 xrH
 khm
-xrH
-xrH
-xrH
-xrH
-xrH
+khm
+sGf
+sGf
+khm
+khm
 khm
 sGf
 sGf
@@ -107780,7 +107277,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (133,1,3) = {"
 bAB
@@ -107899,7 +107396,7 @@ bcr
 bcr
 xrH
 khm
-oeL
+mgQ
 mgQ
 mgQ
 mgQ
@@ -107939,7 +107436,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (134,1,3) = {"
 bAB
@@ -107957,7 +107454,7 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
 bAB
 bAB
 bAB
@@ -108098,7 +107595,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (135,1,3) = {"
 bAB
@@ -108257,7 +107754,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (136,1,3) = {"
 bAB
@@ -108416,7 +107913,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (137,1,3) = {"
 bAB
@@ -108575,7 +108072,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (138,1,3) = {"
 bAB
@@ -108734,7 +108231,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (139,1,3) = {"
 bAB
@@ -108893,7 +108390,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (140,1,3) = {"
 bAB
@@ -109052,7 +108549,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (141,1,3) = {"
 bAB
@@ -109211,7 +108708,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (142,1,3) = {"
 bAB
@@ -109370,7 +108867,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (143,1,3) = {"
 bAB
@@ -109529,7 +109026,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (144,1,3) = {"
 bAB
@@ -109688,7 +109185,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (145,1,3) = {"
 bAB
@@ -109847,7 +109344,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (146,1,3) = {"
 bAB
@@ -110006,7 +109503,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (147,1,3) = {"
 bAB
@@ -110165,7 +109662,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (148,1,3) = {"
 bAB
@@ -110324,7 +109821,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (149,1,3) = {"
 bAB
@@ -110483,7 +109980,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (150,1,3) = {"
 bAB
@@ -110642,7 +110139,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (151,1,3) = {"
 bAB
@@ -110801,7 +110298,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (152,1,3) = {"
 bAB
@@ -110960,7 +110457,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (153,1,3) = {"
 bAB
@@ -111119,7 +110616,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (154,1,3) = {"
 bAB
@@ -111278,7 +110775,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (155,1,3) = {"
 bAB
@@ -111437,7 +110934,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (156,1,3) = {"
 bAB
@@ -111596,7 +111093,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (157,1,3) = {"
 bAB
@@ -111755,7 +111252,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (158,1,3) = {"
 bAB
@@ -111914,7 +111411,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (159,1,3) = {"
 bAB
@@ -112073,7 +111570,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (160,1,3) = {"
 bAB
@@ -112232,7 +111729,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (161,1,3) = {"
 bAB
@@ -112391,7 +111888,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (162,1,3) = {"
 bAB
@@ -112550,7 +112047,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (163,1,3) = {"
 bAB
@@ -112709,7 +112206,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (164,1,3) = {"
 bAB
@@ -112717,9 +112214,9 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -112868,20 +112365,20 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (165,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
 bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -113027,7 +112524,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (166,1,3) = {"
 bAB
@@ -113035,11 +112532,11 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -113186,7 +112683,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (167,1,3) = {"
 bAB
@@ -113196,7 +112693,7 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
 bAB
 bAB
 bAB
@@ -113345,19 +112842,19 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (168,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -113504,19 +113001,19 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (169,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
-pkY
 bAB
-pkY
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -113663,7 +113160,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (170,1,3) = {"
 bAB
@@ -113671,8 +113168,8 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -113822,7 +113319,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (171,1,3) = {"
 bAB
@@ -113842,15 +113339,15 @@ bAB
 bAB
 bAB
 bAB
-pkY
-bAB
-pkY
 bAB
 bAB
 bAB
-jJU
+bAB
+bAB
+bAB
 fGj
-jJU
+fGj
+fGj
 fGj
 bcr
 bcr
@@ -113981,7 +113478,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (172,1,3) = {"
 bAB
@@ -114000,20 +113497,17 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
 bAB
 bAB
 bAB
 bAB
-pkY
-jJU
+bAB
+bAB
+bAB
 fGj
 fGj
 fGj
-bcr
-mzt
-mzt
+fGj
 bcr
 bcr
 bcr
@@ -114022,9 +113516,12 @@ bcr
 bcr
 bcr
 bcr
-mzt
-mzt
-mzt
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
 bcr
 bcr
 bcr
@@ -114140,7 +113637,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (173,1,3) = {"
 bAB
@@ -114148,7 +113645,6 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
@@ -114160,30 +113656,31 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
-pkY
 bAB
-jJU
+bAB
+bAB
+bAB
 fGj
 fGj
 fGj
-mzt
-bcr
-mzt
+fGj
 bcr
 bcr
 bcr
 bcr
 bcr
-mzt
-mzt
-mzt
-mzt
-mzt
-mzt
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
 bcr
 bcr
 bcr
@@ -114299,20 +113796,20 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (174,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
 bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -114327,22 +113824,22 @@ bAB
 bAB
 fGj
 fGj
-jJU
+fGj
 fGj
 bcr
 bcr
-mzt
 bcr
 bcr
 bcr
 bcr
 bcr
-mzt
-mzt
-mzt
-mzt
-mzt
-mzt
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
 bcr
 bcr
 bcr
@@ -114458,7 +113955,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (175,1,3) = {"
 bAB
@@ -114466,42 +113963,42 @@ bAB
 bAB
 bAB
 bAB
-pkY
-bAB
-bAB
-bAB
-pkY
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
-pkY
-pkY
 bAB
 bAB
-pkY
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 fGj
 fGj
 fGj
 fGj
-mzt
-bcr
-mzt
 bcr
 bcr
 bcr
 bcr
 bcr
-mzt
-mzt
-mzt
-mzt
-mzt
-mzt
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
 bcr
 bcr
 bcr
@@ -114617,7 +114114,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (176,1,3) = {"
 bAB
@@ -114627,40 +114124,40 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
-pkY
-pkY
-pkY
 bAB
-pkY
-pkY
 bAB
-pkY
-jJU
-jJU
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 fGj
-jJU
-mzt
-bcr
-mzt
-bcr
+fGj
+fGj
+fGj
 bcr
 bcr
 bcr
 bcr
-mzt
-mzt
-mzt
-mzt
-mzt
-mzt
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
 bcr
 bcr
 bcr
@@ -114776,19 +114273,13 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (177,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
-bAB
-bAB
-bAB
-bAB
-pkY
 bAB
 bAB
 bAB
@@ -114802,24 +114293,30 @@ bAB
 bAB
 bAB
 bAB
-jJU
-jJU
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+fGj
+fGj
 fGj
 fGj
 bcr
 bcr
-mzt
 bcr
 bcr
 bcr
 bcr
 bcr
-mzt
-mzt
-mzt
-mzt
-mzt
-mzt
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
 bcr
 bcr
 bcr
@@ -114935,19 +114432,19 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (178,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
-pkY
 bAB
-pkY
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -114967,7 +114464,7 @@ fGj
 fGj
 bcr
 bcr
-mzt
+bcr
 bcr
 bcr
 bcr
@@ -115094,7 +114591,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (179,1,3) = {"
 bAB
@@ -115102,8 +114599,8 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -115127,18 +114624,18 @@ fGj
 bcr
 bcr
 bcr
-mzt
-mzt
-mzt
-mzt
-mzt
-mzt
-mzt
 bcr
 bcr
-mzt
-mzt
-mzt
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
+bcr
 bcr
 bcr
 bcr
@@ -115253,7 +114750,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (180,1,3) = {"
 bAB
@@ -115412,7 +114909,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (181,1,3) = {"
 bAB
@@ -115571,7 +115068,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (182,1,3) = {"
 bAB
@@ -115579,9 +115076,9 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -115730,20 +115227,13 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (183,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
-bAB
-bAB
-bAB
-bAB
-pkY
 bAB
 bAB
 bAB
@@ -115754,7 +115244,14 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 fGj
 fGj
@@ -115889,7 +115386,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (184,1,3) = {"
 bAB
@@ -115897,11 +115394,11 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -116048,7 +115545,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (185,1,3) = {"
 bAB
@@ -116058,7 +115555,6 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
@@ -116072,26 +115568,27 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
-fGj
-jJU
-fGj
-oSy
-wjy
-fGj
-jJU
-hLz
-hLz
-jJU
-hLz
-hLz
-fGj
-jJU
-jJU
+bAB
+bAB
+bAB
 fGj
 fGj
-jJU
+fGj
+fGj
+bcr
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
 fGj
 fGj
 fGj
@@ -116207,50 +115704,50 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (186,1,3) = {"
 bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
 bAB
-pkY
-pkY
-pkY
-pkY
-pkY
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 bAB
 fGj
 fGj
 fGj
-jJU
-mzt
 fGj
-jJU
+bcr
 fGj
 fGj
-jJU
 fGj
 fGj
-jJU
-jJU
 fGj
-jJU
 fGj
-hLz
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
+fGj
 fGj
 fGj
 fGj
@@ -116366,30 +115863,30 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (187,1,3) = {"
-pkY
 bAB
 bAB
 bAB
-pkY
-pkY
-pkY
-bAB
-pkY
-pkY
 bAB
 bAB
 bAB
-pkY
-pkY
-pkY
-pkY
 bAB
-pkY
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 fGj
@@ -116399,7 +115896,7 @@ fGj
 bcr
 fGj
 fGj
-jJU
+fGj
 fGj
 fGj
 fGj
@@ -116525,10 +116022,9 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (188,1,3) = {"
-pkY
 bAB
 bAB
 bAB
@@ -116548,7 +116044,8 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
 bAB
 bAB
 fGj
@@ -116684,17 +116181,9 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (189,1,3) = {"
-pkY
-bAB
-bAB
-bAB
-bAB
-pkY
-bAB
-pkY
 bAB
 bAB
 bAB
@@ -116707,7 +116196,15 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 fGj
@@ -116718,7 +116215,7 @@ bcr
 fGj
 fGj
 fGj
-jJU
+fGj
 fGj
 fGj
 fGj
@@ -116843,20 +116340,9 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (190,1,3) = {"
-pkY
-bAB
-bAB
-bAB
-pkY
-pkY
-bAB
-bAB
-bAB
-bAB
-pkY
 bAB
 bAB
 bAB
@@ -116866,7 +116352,18 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 fGj
@@ -117002,19 +116499,9 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (191,1,3) = {"
-pkY
-bAB
-bAB
-bAB
-bAB
-pkY
-bAB
-bAB
-bAB
-pkY
 bAB
 bAB
 bAB
@@ -117025,7 +116512,17 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 fGj
@@ -117161,7 +116658,7 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (192,1,3) = {"
 bAB
@@ -117171,7 +116668,6 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
@@ -117185,7 +116681,8 @@ bAB
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
 bAB
 fGj
 fGj
@@ -117320,19 +116817,9 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (193,1,3) = {"
-pkY
-bAB
-bAB
-bAB
-pkY
-bAB
-bAB
-bAB
-bAB
-pkY
 bAB
 bAB
 bAB
@@ -117343,8 +116830,18 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 fGj
 fGj
@@ -117479,19 +116976,9 @@ xrH
 xrH
 xrH
 vvE
-qMJ
+vvE
 "}
 (194,1,3) = {"
-pkY
-bAB
-bAB
-bAB
-pkY
-pkY
-pkY
-bAB
-pkY
-pkY
 bAB
 bAB
 bAB
@@ -117502,8 +116989,18 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 fGj
 fGj
@@ -117641,13 +117138,13 @@ yhC
 vvE
 "}
 (195,1,3) = {"
-jBM
-jBM
 bAB
 bAB
 bAB
-pkY
-pkY
+bAB
+bAB
+bAB
+bAB
 bAB
 bAB
 bAB
@@ -117800,7 +117297,6 @@ yhC
 vvE
 "}
 (196,1,3) = {"
-pkY
 bAB
 bAB
 bAB
@@ -117820,8 +117316,9 @@ bAB
 bAB
 bAB
 bAB
-pkY
-pkY
+bAB
+bAB
+bAB
 bAB
 fGj
 fGj
@@ -117972,15 +117469,15 @@ bAB
 bAB
 bAB
 bAB
-pkY
-jBM
-bAB
-pkY
-pkY
-pkY
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
+bAB
 bAB
 fGj
 fGj
@@ -118130,16 +117627,16 @@ bAB
 bAB
 bAB
 bAB
-pkY
 bAB
 bAB
 bAB
-pkY
-pkY
 bAB
 bAB
 bAB
-pkY
+bAB
+bAB
+bAB
+bAB
 bAB
 fGj
 fGj

--- a/maps/fairpoint/newpoint.dmm
+++ b/maps/fairpoint/newpoint.dmm
@@ -919,6 +919,12 @@
 /area/fairpoint/maintenance/telecomms)
 "blw" = (
 /obj/structure/bookcase/manuals/medical,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "blD" = (
@@ -1143,12 +1149,11 @@
 /turf/simulated/wall/concrete,
 /area/fairpoint/crew_quarters/mayor)
 "buW" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 8
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_sewers)
+/turf/exterior/concrete/pavement/pave_tiling,
+/area/turbolift/sewer_entrance/mining)
 "bvi" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/spline/fancy/wood,
@@ -1505,7 +1510,7 @@
 /area/fairpoint/medical/medbay)
 "bQM" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel_grid,
+/turf/simulated/wall/elevator,
 /area/turbolift/sewer_entrance)
 "bRa" = (
 /obj/structure/cryofeed,
@@ -2037,7 +2042,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "cvo" = (
 /obj/structure/bed/sofa{
 	dir = 1
@@ -3273,12 +3278,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/brig)
 "dwF" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_sewers)
+/turf/simulated/floor/tiled/dark,
+/area/turbolift/pd_top)
 "dxT" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
@@ -3417,7 +3418,7 @@
 "dCb" = (
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "dCh" = (
 /obj/structure/holostool,
 /turf/simulated/floor/carpet,
@@ -4027,9 +4028,14 @@
 /turf/simulated/wall/concrete,
 /area/fairpoint/street)
 "elT" = (
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/plating,
-/area/turbolift/sewer_exit)
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 10
+	},
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "emp" = (
 /obj/random/trash,
 /turf/simulated/floor/plating,
@@ -4145,6 +4151,9 @@
 /obj/structure/bookcase{
 	name = "bookcase (Fiction)"
 	},
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "erX" = (
@@ -4154,7 +4163,7 @@
 "esp" = (
 /obj/structure/disposalpipe/junction,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "esv" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -4271,7 +4280,6 @@
 /turf/simulated/floor/wood/ebony,
 /area/fairpoint/cityhall/meeting_room)
 "ezl" = (
-/obj/structure/lift/button,
 /turf/simulated/wall/concrete,
 /area/turbolift/metro_station)
 "ezz" = (
@@ -4496,9 +4504,8 @@
 /turf/simulated/floor/tiled,
 /area/fairpoint/crew_quarters/kitchen)
 "eMq" = (
-/obj/structure/sign/warning/fall,
 /turf/simulated/wall/concrete,
-/area/fairpoint/street/east)
+/area/turbolift/sewer_entrance/mining)
 "eMJ" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled/monotile,
@@ -5214,12 +5221,13 @@
 /area/fairpoint/medical/patient_c)
 "fBf" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 8
+	dir = 10
 	},
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_surface)
+/area/fairpoint/medical/medbay)
 "fBl" = (
 /obj/effect/floor_decal/corner/grey{
 	tag = "icon-corner_white (NORTHEAST)";
@@ -5709,7 +5717,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "fYD" = (
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/police)
@@ -5970,7 +5978,7 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "glN" = (
 /obj/structure/hygiene/drain/bath,
 /turf/simulated/floor/tiled,
@@ -5993,7 +6001,7 @@
 /area/fairpoint/street/north)
 "gnz" = (
 /obj/turbolift_map_holder/fairpoint/cargo,
-/turf/exterior/concrete/pavement/empty,
+/turf/simulated/floor/tiled/techmaint,
 /area/turbolift/sewer_exit/mining)
 "gnE" = (
 /obj/structure/railing/mapped,
@@ -6163,12 +6171,11 @@
 /area/fairpoint/street/north)
 "gzv" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 8
+	tag = "icon-corner_white (NORTH)";
+	dir = 1
 	},
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_top)
+/area/fairpoint/medical/medbay)
 "gAD" = (
 /turf/simulated/floor/plating,
 /area/fairpoint/street/east)
@@ -6383,7 +6390,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/meeting)
 "gKY" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/hospital_top)
 "gLK" = (
 /obj/effect/floor_decal/corner/pink/bordercorner,
@@ -7411,10 +7418,8 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/cmo)
 "hNC" = (
-/obj/effect/floor_decal/corner/paleblue,
-/obj/effect/floor_decal/industrial/warning/dust,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_sewers)
+/turf/simulated/floor/tiled/dark,
+/area/turbolift/pd_ground)
 "hNI" = (
 /obj/effect/wallframe_spawn/reinforced/bare,
 /turf/simulated/floor,
@@ -8797,13 +8802,9 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/sleeper)
 "jmw" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
-	},
-/obj/structure/railing/mapped,
-/obj/structure/lift/button/standalone,
+/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_surface)
+/area/fairpoint/medical/medbay)
 "jmG" = (
 /obj/effect/floor_decal/corner/white{
 	tag = "icon-corner_white (NORTH)";
@@ -9596,7 +9597,7 @@
 "khH" = (
 /obj/machinery/status_display/supply_display,
 /turf/simulated/wall/concrete,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "khT" = (
 /turf/simulated/floor/tiled,
 /area/fairpoint/street/east)
@@ -9744,9 +9745,6 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/obj/structure/railing/mapped{
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -10306,11 +10304,10 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/chemistry)
 "kSw" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+/obj/structure/sign/warning/fall,
+/turf/simulated/wall/prepainted{
+	color = "FFFEFD"
 	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "kSB" = (
 /obj/structure/window/reinforced{
@@ -10360,7 +10357,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/cityhall)
 "kVN" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/sewer_entrance)
 "kWF" = (
 /turf/exterior/wildgrass,
@@ -10527,7 +10524,7 @@
 	},
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "lgz" = (
 /obj/structure/bed/chair/office/light{
 	tag = "icon-officechair_white (WEST)";
@@ -11109,8 +11106,8 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "lJx" = (
-/turf/simulated/open,
-/area/fairpoint/street/east)
+/turf/unsimulated/mask,
+/area/turbolift/sewer_entrance/mining)
 "lKd" = (
 /obj/structure/railing/mapped{
 	dir = 8
@@ -11128,7 +11125,7 @@
 /turf/simulated/floor/wood/walnut,
 /area/fairpoint/crew_quarters/bar)
 "lLd" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/hospital_surface)
 "lLp" = (
 /obj/structure/table/reinforced,
@@ -11449,7 +11446,7 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/machinery/computer/modular/preset/supply_public,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "meW" = (
 /obj/machinery/light{
 	dir = 4
@@ -12216,7 +12213,7 @@
 /obj/effect/floor_decal/corner/green/diagonal,
 /obj/effect/floor_decal/corner/green/diagonal,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "mXe" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
@@ -12230,7 +12227,7 @@
 	},
 /obj/structure/bed/chair/comfy/green,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "mYN" = (
 /obj/structure/table/reinforced,
 /obj/item/scanner/network,
@@ -13353,7 +13350,6 @@
 /turf/simulated/floor/reinforced,
 /area/fairpoint/panicroom)
 "omu" = (
-/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/turbolift/hospital_sewers)
 "omM" = (
@@ -13546,7 +13542,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "owS" = (
 /obj/machinery/vending/cola{
 	dir = 8
@@ -14048,7 +14044,6 @@
 /turf/exterior/concrete/reinforced/road,
 /area/fairpoint/street/north)
 "oVc" = (
-/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/turbolift/hospital_surface)
 "oVM" = (
@@ -14069,7 +14064,7 @@
 /turf/simulated/wall/concrete,
 /area/fairpoint/cityhall)
 "oXD" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/metro_station)
 "oYh" = (
 /obj/machinery/door/airlock/glass/security,
@@ -14608,7 +14603,7 @@
 /obj/effect/wingrille_spawn/reinforced,
 /obj/structure/sign/cargo,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "pAM" = (
 /obj/structure/railing/mapped{
 	dir = 4
@@ -14748,7 +14743,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/medical/morgue)
 "pHZ" = (
-/obj/effect/floor_decal/industrial/warning/dust,
 /turf/simulated/floor/tiled/white,
 /area/turbolift/hospital_top)
 "pJa" = (
@@ -14947,7 +14941,7 @@
 /turf/simulated/wall/prepainted{
 	color = "FFFEFD"
 	},
-/area/fairpoint/medical/exam_room)
+/area/fairpoint/medical/medbay)
 "pQM" = (
 /turf/simulated/floor/tiled/dark/monotile,
 /area/fairpoint/engineering/sysadmin)
@@ -15412,7 +15406,6 @@
 /area/fairpoint/street/east)
 "qno" = (
 /obj/turbolift_map_holder/fairpoint/metro{
-	level = 3;
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -15457,6 +15450,9 @@
 /area/fairpoint/medical/surgery)
 "qoT" = (
 /obj/structure/coatrack,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/medbay)
 "qpb" = (
@@ -16125,15 +16121,8 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/fairpoint/maintenance/arrivals)
 "qQV" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_top)
+/turf/simulated/wall/elevator,
+/area/fairpoint/police)
 "qRb" = (
 /turf/simulated/floor/wood/mahogany,
 /area/fairpoint/street)
@@ -16854,7 +16843,7 @@
 "rFJ" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "rFL" = (
 /obj/effect/dummy/spell_jaunt,
 /turf/exterior/open,
@@ -17387,12 +17376,13 @@
 /area/fairpoint/police/armoury)
 "sos" = (
 /obj/effect/floor_decal/corner/paleblue{
-	dir = 10
+	dir = 5
 	},
-/obj/structure/railing/mapped,
-/obj/structure/lift/button/standalone,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_top)
+/area/fairpoint/medical/medbay)
 "soL" = (
 /obj/item/trash/candle,
 /turf/simulated/floor/plating,
@@ -17434,11 +17424,12 @@
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/cityhall)
 "spP" = (
-/obj/effect/floor_decal/corner/paleblue,
+/obj/effect/floor_decal/corner/paleblue{
+	dir = 8
+	},
 /obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
 /turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_top)
+/area/fairpoint/medical/medbay)
 "sqy" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/plating,
@@ -17688,7 +17679,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/brig)
 "sDs" = (
-/turf/exterior/concrete/pavement/empty,
+/turf/simulated/floor/tiled/techmaint,
 /area/turbolift/sewer_exit/mining)
 "sEh" = (
 /obj/structure/flora/pottedplant/large{
@@ -18727,12 +18718,8 @@
 /turf/simulated/floor/wood/ebony,
 /area/fairpoint/police/cop)
 "tCz" = (
-/obj/effect/floor_decal/corner/paleblue{
-	dir = 5
-	},
-/obj/structure/lift/button/standalone,
-/turf/simulated/floor/tiled/dark,
-/area/turbolift/pd_ground)
+/turf/simulated/wall/elevator,
+/area/fairpoint/police/cop)
 "tCR" = (
 /turf/exterior/concrete/pavement/corner_invert{
 	dir = 4
@@ -19008,7 +18995,7 @@
 	},
 /area/fairpoint/hydroponics/garden)
 "tTx" = (
-/turf/simulated/open,
+/turf/unsimulated/mask,
 /area/turbolift/pd_top)
 "tTD" = (
 /turf/exterior/concrete/pavement/corner_invert{
@@ -19379,10 +19366,6 @@
 /obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor,
 /area/fairpoint/turret_protected/ai_server_room)
-"umi" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/concrete,
-/area/turbolift/metro_station)
 "umy" = (
 /obj/structure/stairs{
 	dir = 8
@@ -19408,7 +19391,7 @@
 "unl" = (
 /obj/machinery/vending/cola,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "unD" = (
 /obj/structure/table/marble,
 /turf/simulated/floor/tiled/white,
@@ -19689,10 +19672,11 @@
 /turf/simulated/floor/carpet/blue2,
 /area/fairpoint/medical/medbay)
 "uCm" = (
-/obj/structure/table/woodentable,
-/obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/steel_grid,
-/area/turbolift/sewer_entrance)
+/obj/machinery/vending/games{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/fairpoint/hallway/secondary/exit)
 "uDY" = (
 /obj/machinery/hologram/holopad,
 /turf/simulated/floor/wood/walnut,
@@ -20016,12 +20000,6 @@
 /obj/effect/floor_decal/borderfloorwhite,
 /turf/simulated/floor/tiled/freezer,
 /area/fairpoint/street/north)
-"uYN" = (
-/obj/structure/sign/warning/fall,
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/fairpoint/medical/exam_room)
 "uYV" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
@@ -21020,7 +20998,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "wiQ" = (
 /turf/simulated/floor/tiled/steel_ridged,
 /area/fairpoint/library)
@@ -21219,11 +21197,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/fairpoint/police/brig/solitaryA)
 "wsV" = (
-/obj/structure/sign/warning,
-/turf/simulated/wall/prepainted{
-	color = "FFFEFD"
-	},
-/area/turbolift/hospital_surface)
+/obj/effect/floor_decal/corner/paleblue,
+/obj/effect/floor_decal/industrial/warning/dust,
+/turf/simulated/floor/tiled/white,
+/area/fairpoint/medical/medbay)
 "wtb" = (
 /obj/machinery/optable,
 /turf/simulated/floor/tiled/white,
@@ -21292,7 +21269,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "wxH" = (
 /obj/machinery/power/apc{
 	dir = 4;
@@ -21575,11 +21552,8 @@
 /turf/simulated/floor/tiled/white,
 /area/fairpoint/medical/surgery)
 "wHm" = (
-/obj/effect/floor_decal/corner/paleblue,
-/obj/effect/floor_decal/industrial/warning/dust,
-/obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/white,
-/area/turbolift/hospital_surface)
+/turf/simulated/floor/tiled/dark,
+/area/fairpoint/shipping/office)
 "wHB" = (
 /obj/machinery/door/morgue{
 	name = "Confession Booth"
@@ -22841,9 +22815,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/structure/railing/mapped{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/turbolift/pd_top)
 "xUH" = (
@@ -23000,7 +22971,7 @@
 "ycY" = (
 /obj/effect/wingrille_spawn/reinforced,
 /turf/simulated/floor/tiled/dark,
-/area/fairpoint/street/east)
+/area/fairpoint/shipping/office)
 "ydD" = (
 /obj/structure/curtain/open/shower/security,
 /obj/structure/hygiene/shower,
@@ -23117,9 +23088,8 @@
 /turf/simulated/wall/r_wall/hull,
 /area/fairpoint/street)
 "yic" = (
-/obj/machinery/vending/games,
-/turf/simulated/floor/tiled,
-/area/fairpoint/hallway/secondary/exit)
+/turf/simulated/wall/concrete,
+/area/turbolift/sewer_exit/mining)
 "yii" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -29370,7 +29340,7 @@ dpT
 dpT
 dpT
 qBc
-yic
+bZC
 gSq
 gSq
 gSq
@@ -38928,8 +38898,8 @@ lPK
 vxu
 lFO
 nLU
-ale
 kKq
+plm
 plm
 plm
 oQa
@@ -39087,9 +39057,9 @@ nlo
 nlo
 lFO
 pjG
-ale
-dwF
+ieA
 xpr
+bzn
 bzn
 bzn
 bzn
@@ -39246,8 +39216,8 @@ nlo
 nlo
 lBO
 ale
-ale
-buW
+spP
+bzn
 lUA
 lUA
 lUA
@@ -39405,7 +39375,7 @@ lPK
 vxu
 qHq
 wJa
-ale
+jmw
 omu
 lUA
 lUA
@@ -39564,7 +39534,7 @@ auf
 pCL
 pCL
 uzP
-ale
+jmw
 omu
 lUA
 lUA
@@ -39723,7 +39693,7 @@ lPK
 vxu
 iLD
 ygv
-ale
+jmw
 omu
 lUA
 lUA
@@ -39882,8 +39852,8 @@ nlo
 nlo
 lFO
 tAK
-ale
-hNC
+wsV
+bzn
 lUA
 lUA
 lUA
@@ -40041,9 +40011,9 @@ nlo
 nlo
 lBO
 ale
-ale
 ieA
 pQK
+fqK
 fqK
 fqK
 fqK
@@ -40200,8 +40170,8 @@ nlo
 nlo
 lFO
 wJa
-ale
-ieA
+wZN
+fBf
 fqK
 fmy
 klu
@@ -50069,15 +50039,15 @@ aLC
 aLC
 aLC
 aLC
-obM
-obM
-obM
-obM
-obM
-obM
+yic
+yic
+yic
+yic
+yic
+yic
+yic
 kLV
 jYE
-aLC
 aLC
 dpT
 dpT
@@ -50228,15 +50198,15 @@ aLC
 aLC
 aLC
 aLC
-obM
+yic
 sDs
 sDs
 sDs
 sDs
 gnz
+yic
 kLV
 jYE
-aLC
 aLC
 wEt
 wEt
@@ -50387,7 +50357,8 @@ aLC
 aLC
 aLC
 aLC
-obM
+yic
+sDs
 sDs
 sDs
 sDs
@@ -50395,7 +50366,6 @@ sDs
 sDs
 kLV
 jYE
-aLC
 aLC
 wEt
 wEt
@@ -50546,7 +50516,8 @@ aLC
 aLC
 aLC
 aLC
-obM
+yic
+sDs
 sDs
 sDs
 sDs
@@ -50554,7 +50525,6 @@ sDs
 sDs
 kLV
 jYE
-aLC
 aLC
 wEt
 wEt
@@ -50705,7 +50675,8 @@ dpT
 dpT
 dpT
 dpT
-obM
+yic
+sDs
 sDs
 sDs
 sDs
@@ -50714,7 +50685,6 @@ sDs
 kLV
 jYE
 dpT
-jbX
 wEt
 wEt
 wEt
@@ -50864,15 +50834,15 @@ dpT
 dpT
 dpT
 dpT
-obM
+yic
 sDs
 sDs
 sDs
 sDs
 sDs
+yic
 xuF
 bIo
-dSf
 dSf
 wEt
 wEt
@@ -51023,15 +50993,15 @@ bIo
 bIo
 bIo
 bIo
-obM
-obM
-obM
-obM
-obM
-obM
+yic
+yic
+yic
+yic
+yic
+yic
+yic
 xuF
 bIo
-dSf
 dSf
 wEt
 wEt
@@ -53017,7 +52987,7 @@ rxV
 qQA
 qXt
 qXt
-elT
+rxV
 rxV
 dpT
 dpT
@@ -61016,7 +60986,7 @@ ezl
 sHL
 sHL
 sHL
-umi
+ezl
 nsJ
 nsJ
 hYI
@@ -61171,7 +61141,7 @@ eJq
 eJq
 eJq
 qBc
-yic
+bZC
 gSq
 gSq
 gSq
@@ -61651,7 +61621,7 @@ qBc
 pmr
 gSq
 gSq
-bZC
+uCm
 vHA
 nTD
 gDs
@@ -67287,7 +67257,7 @@ pBu
 pBu
 pBu
 nTB
-tCz
+sty
 xoA
 mXe
 hwc
@@ -67440,12 +67410,12 @@ ncP
 ncP
 kaB
 lqs
-pBu
 ezz
 ezz
 hZR
 hZR
 xJp
+pBu
 oHA
 xoA
 mXe
@@ -67599,12 +67569,12 @@ szv
 ncP
 kaB
 lqs
-pBu
 wIN
 wIN
 wIN
 wIN
 wIN
+hNC
 djF
 xoA
 sqN
@@ -67758,12 +67728,12 @@ szv
 ncP
 kaB
 lqs
-pBu
 msl
 msl
 msl
 msl
 msl
+hNC
 djF
 xoA
 xoA
@@ -67917,12 +67887,12 @@ szv
 ncP
 fxX
 lqs
-pBu
 ezz
 ezz
 hZR
 ezz
 jzJ
+hNC
 djF
 xoA
 cPe
@@ -68076,12 +68046,12 @@ szv
 ncP
 kaB
 lqs
-pBu
 ezz
 ezz
 hZR
 hZR
 jzJ
+pBu
 oHA
 xoA
 mXe
@@ -70729,8 +70699,8 @@ vbj
 lLp
 ptk
 nLU
-ale
 kKq
+plm
 plm
 plm
 plm
@@ -70888,9 +70858,9 @@ aKK
 hdt
 qQv
 pjG
-ale
-jmw
-wsV
+ieA
+tVj
+tVj
 tVj
 tVj
 tVj
@@ -71047,8 +71017,8 @@ dRg
 dfl
 wHk
 ale
-ale
-fBf
+spP
+tVj
 lLd
 lLd
 lLd
@@ -71206,7 +71176,7 @@ jdE
 pac
 qfr
 aac
-ale
+jmw
 oVc
 lLd
 lLd
@@ -71365,7 +71335,7 @@ pQz
 qou
 qQv
 uzP
-ale
+jmw
 oVc
 lLd
 lLd
@@ -71524,7 +71494,7 @@ ntQ
 adF
 rlj
 ygv
-ale
+jmw
 oVc
 lLd
 lLd
@@ -71683,8 +71653,8 @@ eVT
 kPh
 adF
 pjG
-ale
-wHm
+wsV
+tVj
 lLd
 lLd
 lLd
@@ -71842,9 +71812,9 @@ eVT
 mTo
 dFA
 ale
-ale
-kSw
-uYN
+ieA
+oTt
+fqK
 fqK
 fqK
 fqK
@@ -72001,8 +71971,8 @@ eVT
 inN
 adF
 aac
-ale
-ieA
+wZN
+fBf
 fqK
 fmy
 klu
@@ -81870,13 +81840,13 @@ kbw
 kbw
 wGV
 mON
-oyq
-oyq
-oyq
-oyq
-oyq
-oyq
-oyq
+eMq
+eMq
+eMq
+eMq
+eMq
+eMq
+eMq
 wNm
 wNm
 mON
@@ -82029,14 +81999,14 @@ xvf
 kso
 ptG
 mON
-oyq
+eMq
 lJx
 lJx
 lJx
 lJx
 lJx
 eMq
-wNm
+fVE
 wNm
 mON
 mON
@@ -82188,14 +82158,14 @@ ejQ
 ejQ
 ptG
 mON
-oyq
+eMq
 lJx
 lJx
 lJx
 lJx
 lJx
+buW
 fVE
-wNm
 wNm
 mON
 mON
@@ -82321,12 +82291,12 @@ uaP
 aOh
 oyq
 mON
-oyq
-oyq
+sHp
+sHp
 ycY
 pAE
-pus
-pus
+wHm
+wHm
 ycY
 ycY
 sHp
@@ -82347,14 +82317,14 @@ cSd
 cSd
 wGV
 mON
-oyq
+eMq
 lJx
 lJx
 lJx
 lJx
 lJx
+buW
 fVE
-wNm
 wNm
 mON
 mON
@@ -82480,12 +82450,12 @@ hUy
 hUy
 oyq
 mON
-oyq
-oyq
+sHp
+sHp
 owp
 wiE
-pus
-pus
+wHm
+wHm
 cvn
 unl
 sHp
@@ -82506,14 +82476,14 @@ ejQ
 ejQ
 wGV
 mON
-oyq
+eMq
 lJx
 lJx
 lJx
 lJx
 lJx
+buW
 fVE
-wNm
 wNm
 mON
 mON
@@ -82639,8 +82609,8 @@ fQz
 fQz
 paq
 iqY
-paq
-paq
+eWn
+eWn
 rFJ
 rFJ
 rFJ
@@ -82665,14 +82635,14 @@ res
 res
 ptG
 mON
-oyq
+eMq
 lJx
 lJx
 lJx
 lJx
 lJx
-oyq
-wNm
+eMq
+fVE
 wNm
 mON
 mON
@@ -82798,8 +82768,8 @@ hUy
 hUy
 oyq
 mON
-oyq
-oyq
+sHp
+sHp
 mYE
 fYx
 wxq
@@ -82824,13 +82794,13 @@ ejQ
 sEM
 ptG
 mON
-oyq
-oyq
-oyq
-oyq
-oyq
-oyq
-oyq
+eMq
+eMq
+eMq
+eMq
+eMq
+eMq
+eMq
 wNm
 wNm
 mON
@@ -82957,7 +82927,7 @@ hUy
 hUy
 oyq
 mJD
-oyq
+sHp
 khH
 glI
 dCb
@@ -83116,8 +83086,8 @@ hUy
 hUy
 oyq
 mON
-oyq
-oyq
+sHp
+sHp
 meR
 dCb
 mWO
@@ -84818,7 +84788,7 @@ bQM
 xnx
 xnx
 xnx
-uCm
+bQM
 iZi
 gcT
 hDh
@@ -99081,14 +99051,14 @@ wUR
 wUR
 wUR
 wUR
-wUR
+tCz
 nFK
 nFK
 nFK
 nFK
 nFK
 eIC
-qQV
+xUG
 xoA
 mXe
 hwc
@@ -99240,13 +99210,13 @@ wUR
 wUR
 wUR
 wUR
-wUR
+tCz
+tTx
+tTx
+tTx
+tTx
+tTx
 nFK
-tTx
-tTx
-tTx
-tTx
-tTx
 kqI
 xoA
 mXe
@@ -99399,13 +99369,13 @@ wUR
 wUR
 wUR
 wUR
-wUR
-nFK
+tCz
 tTx
 tTx
 tTx
 tTx
 tTx
+dwF
 aVC
 xoA
 mXe
@@ -99558,13 +99528,13 @@ wUR
 wUR
 wUR
 wUR
-wUR
-nFK
+tCz
 tTx
 tTx
 tTx
 tTx
 tTx
+dwF
 aVC
 xoA
 sqN
@@ -99717,13 +99687,13 @@ wUR
 wUR
 wUR
 wUR
-wUR
-nFK
+tCz
 tTx
 tTx
 tTx
 tTx
 tTx
+dwF
 aVC
 xoA
 cPe
@@ -99832,7 +99802,7 @@ duA
 duA
 duA
 hrD
-ale
+nLU
 ale
 ale
 ale
@@ -99876,13 +99846,13 @@ wUR
 wUR
 wUR
 wUR
-wUR
+tCz
+tTx
+tTx
+tTx
+tTx
+tTx
 nFK
-tTx
-tTx
-tTx
-tTx
-tTx
 kqI
 xoA
 mXe
@@ -99991,7 +99961,7 @@ kVg
 kiW
 kiW
 igB
-ale
+gzv
 ale
 ale
 ale
@@ -100035,7 +100005,7 @@ ncP
 ncP
 ncP
 ncP
-ncP
+qQV
 nFK
 kZv
 nFK
@@ -100150,7 +100120,7 @@ kVg
 kiW
 kiW
 kiW
-ale
+aac
 ale
 ale
 vmx
@@ -100309,7 +100279,7 @@ toy
 toy
 toy
 ckN
-ale
+nLU
 ale
 ale
 qNn
@@ -100468,7 +100438,7 @@ edj
 wMp
 wMp
 ckN
-ale
+nLU
 ale
 ale
 wyW
@@ -100627,7 +100597,7 @@ jyb
 hrD
 hrD
 hrD
-ale
+nLU
 ale
 ale
 ale
@@ -100783,15 +100753,15 @@ jKv
 jyb
 jyb
 jyb
+sos
+gdm
+gdm
+pjG
 ale
 ale
 ale
 ale
-ale
-ale
-ale
-ale
-ale
+ieA
 qFl
 ale
 ale
@@ -100942,11 +100912,11 @@ oQb
 iOL
 eFQ
 jyb
+nLU
 ale
 ale
 ale
-ale
-ale
+kKq
 qoT
 qoT
 erV
@@ -101101,11 +101071,11 @@ lIC
 pMp
 lsb
 jyb
+nLU
 ale
 ale
 ale
-ale
-ale
+ieA
 eri
 eri
 eri
@@ -101260,11 +101230,11 @@ lIC
 pMp
 lsb
 jyb
+nLU
 ale
 ale
 ale
-ale
-ale
+ieA
 eri
 aAq
 aAq
@@ -101419,11 +101389,11 @@ oJe
 tnk
 aLx
 jyb
+nLU
 ale
 ale
 ale
-ale
-ale
+ieA
 eri
 aAq
 aAq
@@ -101578,11 +101548,11 @@ rlM
 vlI
 vlI
 jyb
+nLU
 ale
 ale
 ale
-ale
-ale
+ieA
 eri
 aAq
 aAq
@@ -101733,11 +101703,11 @@ jyb
 aeY
 jyb
 jyb
-nLU
 ale
-ale
-ale
-ale
+wZN
+gdm
+gdm
+pjG
 ale
 ale
 ale
@@ -101892,15 +101862,15 @@ bqd
 ikI
 fsB
 jyb
-nLU
+aac
 ale
 ale
 ale
-ale
-ale
-ale
-ale
-ale
+kKq
+plm
+plm
+plm
+elT
 eri
 aAq
 aAq
@@ -102055,7 +102025,7 @@ nLU
 ale
 ale
 ale
-ale
+ieA
 uWr
 uWr
 uWr
@@ -102214,7 +102184,7 @@ nLU
 ale
 ale
 ale
-ale
+ieA
 uWr
 twE
 qyR
@@ -102373,7 +102343,7 @@ nLU
 ale
 ale
 ale
-ale
+ieA
 uWr
 twE
 xGr
@@ -102530,9 +102500,9 @@ lXk
 lXk
 nLU
 ale
-ale
-ale
-ale
+kKq
+plm
+elT
 uWr
 aDR
 paC
@@ -102689,9 +102659,9 @@ wUn
 lXk
 nVj
 ale
-ale
-sos
+ieA
 ehr
+eQV
 eQV
 eQV
 eQV
@@ -102848,8 +102818,8 @@ kUl
 uaa
 ale
 ale
-ale
-gzv
+spP
+eQV
 gKY
 gKY
 gKY
@@ -103007,7 +102977,7 @@ dyM
 lXk
 gQP
 ale
-ale
+jmw
 pHZ
 gKY
 gKY
@@ -103166,7 +103136,7 @@ dyM
 kGi
 nLU
 ale
-ale
+jmw
 pHZ
 gKY
 gKY
@@ -103325,7 +103295,7 @@ dyM
 kGi
 nLU
 ale
-ale
+jmw
 pHZ
 gKY
 gKY
@@ -103484,8 +103454,8 @@ dyM
 lXk
 vqg
 ale
-ale
-spP
+wsV
+eQV
 gKY
 gKY
 gKY
@@ -103643,9 +103613,9 @@ yhb
 lXk
 nLU
 ale
-ale
+ieA
 kSw
-uYN
+fqK
 fqK
 fqK
 fqK
@@ -103802,8 +103772,8 @@ lXk
 vka
 wJa
 ale
-ale
-ieA
+wZN
+fBf
 fqK
 fmy
 klu


### PR DESCRIPTION
## Description of changes
-Elevator setup similar to Exodus [Masking applied to empty shafts] 
-Elevator default increased to 4x4 to fit the frames 
-Several edits made to make the elevator spots fit the generated sections

## Why and what will this PR improve
Pray that it fixes Elevators

## Authorship
If this doesnt work, I blame whoever wrote the map tool for the turbolifts

## Changelog
:cl:
add: Added new elevator shaft edits
fix: Elevator fix?
/:cl: